### PR TITLE
Rename profiles table to employee_info

### DIFF
--- a/src/components/admin/employees/EmployeeImportPage.tsx
+++ b/src/components/admin/employees/EmployeeImportPage.tsx
@@ -154,7 +154,7 @@ const EmployeeImportPage = () => {
       if (!user) throw new Error('User not authenticated');
 
       const { data: profile } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('organization_id, first_name, last_name, name')
         .eq('user_id', user.id)
         .single();

--- a/src/components/admin/employees/types.ts
+++ b/src/components/admin/employees/types.ts
@@ -1,6 +1,6 @@
 import { Tables } from "@/integrations/supabase/types";
 
-export interface Employee extends Tables<'profiles'> {
+export interface Employee extends Tables<'employee_info'> {
   role?: Tables<'roles'>;
   division?: Tables<'divisions'>;
   department?: Tables<'departments'>;

--- a/src/components/admin/reports/ReportsPage.tsx
+++ b/src/components/admin/reports/ReportsPage.tsx
@@ -24,7 +24,7 @@ const ReportsPage = () => {
         { data: appraisals },
         { data: completedAppraisals }
       ] = await Promise.all([
-        supabase.from('profiles').select('id').eq('status', 'active'),
+        supabase.from('employee_info').select('id').eq('status', 'active'),
         supabase.from('goals').select('id'),
         supabase.from('appraisals').select('id'),
         supabase.from('appraisals').select('id').eq('status', 'completed')

--- a/src/components/onboarding/components/AppraiserAssignmentModal.tsx
+++ b/src/components/onboarding/components/AppraiserAssignmentModal.tsx
@@ -62,7 +62,7 @@ export default function AppraiserAssignmentModal({
       // Note: This function was created in the migration but may not be available yet
       // For now, we'll use a simple fallback
       const { data, error } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('id, name, email')
         .eq('status', 'active')
         .neq('id', employee.id)
@@ -98,7 +98,7 @@ export default function AppraiserAssignmentModal({
   const loadAllEmployees = async () => {
     try {
       const { data, error } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select(`
           id,
           name,
@@ -164,7 +164,7 @@ export default function AppraiserAssignmentModal({
       if (!currentUser.user) throw new Error('Not authenticated');
 
       const { data: profile } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('id')
         .eq('user_id', currentUser.user.id)
         .single();

--- a/src/components/onboarding/components/OrganizationalChart.tsx
+++ b/src/components/onboarding/components/OrganizationalChart.tsx
@@ -85,7 +85,7 @@ export default function OrganizationalChart({
 
       // Load employees with their roles
       const { data: employeesData, error: employeesError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select(`
           id,
           name,

--- a/src/hooks/useEmployeeInvitation.ts
+++ b/src/hooks/useEmployeeInvitation.ts
@@ -20,7 +20,7 @@ export const useEmployeeInvitation = () => {
       }
 
       const { data: profile, error: profileError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('organization_id')
         .eq('user_id', userData.user.id)
         .single();
@@ -31,7 +31,7 @@ export const useEmployeeInvitation = () => {
 
       // Create the invited employee profile
       const { data: newProfile, error: createError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .insert({
           email: employeeData.email,
           first_name: employeeData.firstName,
@@ -66,7 +66,7 @@ export const useEmployeeInvitation = () => {
     try {
       // Find existing profile with this email that hasn't been claimed
       const { data: existingProfile, error: findError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('id')
         .eq('email', email)
         .is('user_id', null)
@@ -78,7 +78,7 @@ export const useEmployeeInvitation = () => {
 
       // Update the profile to link it to the user
       const { error: updateError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .update({
           user_id: userId,
           status: 'active'

--- a/src/hooks/useOnboardingPersistence.ts
+++ b/src/hooks/useOnboardingPersistence.ts
@@ -20,7 +20,7 @@ export const useOnboardingPersistence = () => {
       
       // Get user's organization ID and profile ID from their profile
       const { data: profile, error: profileError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('id, organization_id')
         .eq('user_id', userId)
         .single();
@@ -60,7 +60,7 @@ export const useOnboardingPersistence = () => {
           throw new Error(`Failed to import employees: ${importError.message}`);
         }
         
-        operations.push('profiles');
+        operations.push('employee_info');
       }
 
       // 3. Save organizational structure
@@ -121,7 +121,7 @@ export const useOnboardingPersistence = () => {
 
       // 5. Mark onboarding as completed for the admin user
       const { error: onboardingError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .update({
           onboarding_completed: true,
           onboarding_completed_at: new Date().toISOString()

--- a/src/hooks/useOnboardingStatus.ts
+++ b/src/hooks/useOnboardingStatus.ts
@@ -21,7 +21,7 @@ export function useOnboardingStatus() {
 
     try {
       const { data, error } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('onboarding_completed, onboarding_completed_at')
         .eq('user_id', user.id)
         .single();
@@ -43,7 +43,7 @@ export function useOnboardingStatus() {
     try {
       // First, get the user's profile to get profile_id and organization_id
       const { data: profile, error: profileError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('id, organization_id')
         .eq('user_id', user.id)
         .single();
@@ -53,7 +53,7 @@ export function useOnboardingStatus() {
 
       // Update onboarding completion status
       const { error: updateError } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .update({
           onboarding_completed: true,
           onboarding_completed_at: new Date().toISOString()

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -64,7 +64,7 @@ export function useProfile() {
 
     try {
       const { data, error } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .select('*')
         .eq('user_id', user.id)
         .single();
@@ -87,7 +87,7 @@ export function useProfile() {
         supabase.from('departments').select('*'),
         supabase.from('divisions').select('*'),
         supabase.from('roles').select('*'),
-        supabase.from('profiles').select('id, first_name, last_name, name, job_title').neq('user_id', user?.id || '')
+        supabase.from('employee_info').select('id, first_name, last_name, name, job_title').neq('user_id', user?.id || '')
       ]);
 
       if (departmentsRes.error) throw departmentsRes.error;
@@ -110,7 +110,7 @@ export function useProfile() {
     setUpdating(true);
     try {
       const { data, error } = await supabase
-        .from('profiles')
+        .from('employee_info')
         .update({
           ...updates,
           updated_at: new Date().toISOString()

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -63,14 +63,14 @@ export type Database = {
             foreignKeyName: "appraisal_appraisers_appraiser_id_fkey"
             columns: ["appraiser_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "appraisal_appraisers_assigned_by_fkey"
             columns: ["assigned_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -143,7 +143,7 @@ export type Database = {
             foreignKeyName: "appraisals_employee_id_fkey"
             columns: ["employee_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -279,7 +279,7 @@ export type Database = {
             foreignKeyName: "competency_ratings_appraiser_id_fkey"
             columns: ["appraiser_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -340,7 +340,7 @@ export type Database = {
             foreignKeyName: "cycles_created_by_fkey"
             columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -436,14 +436,14 @@ export type Database = {
             foreignKeyName: "division_goals_approved_by_fkey"
             columns: ["approved_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "division_goals_created_by_fkey"
             columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -541,7 +541,7 @@ export type Database = {
             foreignKeyName: "goal_ratings_appraiser_id_fkey"
             columns: ["appraiser_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -643,14 +643,14 @@ export type Database = {
             foreignKeyName: "goals_employee_id_fkey"
             columns: ["employee_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "goals_manager_id_fkey"
             columns: ["manager_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -671,7 +671,7 @@ export type Database = {
             foreignKeyName: "goals_supervisor_id_fkey"
             columns: ["supervisor_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
         ]
@@ -748,7 +748,7 @@ export type Database = {
           },
         ]
       }
-      profiles: {
+      employee_info: {
         Row: {
           avatar_url: string | null
           created_at: string
@@ -849,7 +849,7 @@ export type Database = {
             foreignKeyName: "profiles_manager_id_fkey"
             columns: ["manager_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -907,7 +907,7 @@ export type Database = {
             foreignKeyName: "role_audit_log_assigned_by_fkey"
             columns: ["assigned_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -921,7 +921,7 @@ export type Database = {
             foreignKeyName: "role_audit_log_profile_id_fkey"
             columns: ["profile_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
         ]
@@ -1009,14 +1009,14 @@ export type Database = {
             foreignKeyName: "user_roles_assigned_by_fkey"
             columns: ["assigned_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "user_roles_deactivated_by_fkey"
             columns: ["deactivated_by"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
           {
@@ -1030,7 +1030,7 @@ export type Database = {
             foreignKeyName: "user_roles_profile_id_fkey"
             columns: ["profile_id"]
             isOneToOne: false
-            referencedRelation: "profiles"
+            referencedRelation: "employee_info"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/functions/import-employees/index.ts
+++ b/supabase/functions/import-employees/index.ts
@@ -237,7 +237,7 @@ serve(async (req) => {
         }
 
         const { data: profile, error: profileError } = await supabaseAdmin
-          .from('profiles')
+          .from('employee_info')
           .upsert(profileData, { onConflict: 'email,organization_id' })
           .select('id')
           .single()
@@ -325,7 +325,7 @@ serve(async (req) => {
     // Update admin user's profile
     try {
       const { error: adminUpdateError } = await supabaseAdmin
-        .from('profiles')
+        .from('employee_info')
         .update({
           organization_id: organizationId,
           first_name: adminInfo.name.split(' ')[0] || adminInfo.name,

--- a/supabase/migrations/20250722232141-bc579618-5466-4ace-be4e-a28cde5c35ad.sql
+++ b/supabase/migrations/20250722232141-bc579618-5466-4ace-be4e-a28cde5c35ad.sql
@@ -1,0 +1,455 @@
+-- Rename profiles table to employee_info
+ALTER TABLE public.profiles RENAME TO employee_info;
+
+-- Rename indexes referencing the old table
+ALTER INDEX IF EXISTS idx_profiles_organization_id RENAME TO idx_employee_info_organization_id;
+ALTER INDEX IF EXISTS idx_profiles_user_id RENAME TO idx_employee_info_user_id;
+ALTER INDEX IF EXISTS idx_profiles_manager_id RENAME TO idx_employee_info_manager_id;
+ALTER INDEX IF EXISTS idx_profiles_division_id RENAME TO idx_employee_info_division_id;
+ALTER INDEX IF EXISTS idx_profiles_department_id RENAME TO idx_employee_info_department_id;
+ALTER INDEX IF EXISTS idx_profiles_role_id RENAME TO idx_employee_info_role_id;
+ALTER INDEX IF EXISTS idx_profiles_status RENAME TO idx_employee_info_status;
+ALTER INDEX IF EXISTS idx_profiles_invitation_token RENAME TO idx_employee_info_invitation_token;
+
+-- Update handle_new_user function to use new table name
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  existing_profile_id UUID;
+  default_org_id UUID;
+BEGIN
+  SELECT id INTO existing_profile_id
+  FROM public.employee_info
+  WHERE email = NEW.email
+    AND user_id IS NULL
+  LIMIT 1;
+
+  IF existing_profile_id IS NOT NULL THEN
+    UPDATE public.employee_info
+    SET
+      user_id = NEW.id,
+      first_name = COALESCE(NEW.raw_user_meta_data ->> 'first_name', first_name),
+      last_name = COALESCE(NEW.raw_user_meta_data ->> 'last_name', last_name),
+      status = 'active',
+      updated_at = now()
+    WHERE id = existing_profile_id;
+  ELSE
+    SELECT id INTO default_org_id
+    FROM public.organizations
+    WHERE name = 'Default Organization'
+    LIMIT 1;
+
+    IF default_org_id IS NULL THEN
+      INSERT INTO public.organizations (name, domain)
+      VALUES ('Default Organization', NULL)
+      RETURNING id INTO default_org_id;
+    END IF;
+
+    INSERT INTO public.employee_info (user_id, email, first_name, last_name, organization_id, status)
+    VALUES (
+      NEW.id,
+      NEW.email,
+      NEW.raw_user_meta_data ->> 'first_name',
+      NEW.raw_user_meta_data ->> 'last_name',
+      COALESCE((NEW.raw_user_meta_data ->> 'organization_id')::UUID, default_org_id),
+      'active'
+    );
+  END IF;
+
+  RETURN NEW;
+EXCEPTION
+  WHEN OTHERS THEN
+    RAISE WARNING 'Error in handle_new_user: %', SQLERRM;
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Update determine_role_from_position function
+CREATE OR REPLACE FUNCTION public.determine_role_from_position(_profile_id UUID)
+RETURNS public.app_role[]
+LANGUAGE PLPGSQL
+SECURITY DEFINER
+AS $function$
+DECLARE
+  profile_record RECORD;
+  determined_roles public.app_role[] := ARRAY[]::public.app_role[];
+  is_division_head BOOLEAN := false;
+  is_department_head BOOLEAN := false;
+  has_supervisor_title BOOLEAN := false;
+BEGIN
+  SELECT p.*, d.name as department_name, div.name as division_name
+  INTO profile_record
+  FROM public.employee_info p
+  LEFT JOIN public.departments d ON d.id = p.department_id
+  LEFT JOIN public.divisions div ON div.id = p.division_id
+  WHERE p.id = _profile_id;
+
+  IF NOT FOUND THEN
+    RETURN ARRAY['employee']::public.app_role[];
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM public.divisions
+    WHERE id = profile_record.division_id
+      AND organization_id = profile_record.organization_id
+  ) INTO is_division_head;
+
+  SELECT EXISTS(
+    SELECT 1 FROM public.departments
+    WHERE id = profile_record.department_id
+      AND organization_id = profile_record.organization_id
+  ) INTO is_department_head;
+
+  IF profile_record.job_title IS NOT NULL THEN
+    has_supervisor_title := (
+      LOWER(profile_record.job_title) LIKE '%supervisor%' OR
+      LOWER(profile_record.job_title) LIKE '%lead%' OR
+      LOWER(profile_record.job_title) LIKE '%coordinator%'
+    );
+  END IF;
+
+  determined_roles := determined_roles || 'employee';
+
+  IF has_supervisor_title THEN
+    determined_roles := determined_roles || 'supervisor';
+  END IF;
+
+  IF is_department_head THEN
+    determined_roles := determined_roles || 'manager';
+  END IF;
+
+  IF is_division_head THEN
+    determined_roles := determined_roles || 'director';
+  END IF;
+
+  RETURN determined_roles;
+END;
+$function$;
+
+-- Update sync_user_roles function
+CREATE OR REPLACE FUNCTION public.sync_user_roles(_profile_id uuid, _assigned_by uuid DEFAULT NULL::uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  profile_record RECORD;
+  determined_roles public.app_role[];
+  role_item public.app_role;
+  existing_roles public.app_role[];
+  roles_to_add public.app_role[];
+  roles_to_remove public.app_role[];
+BEGIN
+  SELECT * INTO profile_record FROM public.employee_info WHERE id = _profile_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF profile_record.user_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  determined_roles := public.determine_role_from_position(_profile_id);
+
+  SELECT ARRAY_AGG(role) INTO existing_roles
+  FROM public.user_roles
+  WHERE profile_id = _profile_id
+    AND role != 'admin'
+    AND is_active = true;
+
+  IF existing_roles IS NULL THEN
+    existing_roles := ARRAY[]::public.app_role[];
+  END IF;
+
+  SELECT ARRAY(
+    SELECT unnest(determined_roles)
+    EXCEPT
+    SELECT unnest(existing_roles)
+  ) INTO roles_to_add;
+
+  SELECT ARRAY(
+    SELECT unnest(existing_roles)
+    EXCEPT
+    SELECT unnest(determined_roles)
+  ) INTO roles_to_remove;
+
+  IF array_length(roles_to_remove, 1) > 0 THEN
+    FOREACH role_item IN ARRAY roles_to_remove
+    LOOP
+      UPDATE public.user_roles
+      SET is_active = false,
+          deactivated_by = _assigned_by,
+          deactivated_at = now(),
+          updated_at = now()
+      WHERE profile_id = _profile_id
+        AND role = role_item
+        AND is_active = true;
+
+      INSERT INTO public.role_audit_log (
+        profile_id, old_role, new_role, action_type, assigned_by,
+        reason, organization_id
+      ) VALUES (
+        _profile_id, role_item, NULL, 'removed', _assigned_by,
+        'Automatic role sync based on position', profile_record.organization_id
+      );
+    END LOOP;
+  END IF;
+
+  IF array_length(roles_to_add, 1) > 0 THEN
+    FOREACH role_item IN ARRAY roles_to_add
+    LOOP
+      INSERT INTO public.user_roles (profile_id, user_id, role, organization_id, assigned_by)
+      VALUES (_profile_id, profile_record.user_id, role_item, profile_record.organization_id, _assigned_by)
+      ON CONFLICT (profile_id, role, organization_id)
+      DO UPDATE SET
+        is_active = true,
+        user_id = profile_record.user_id,
+        assigned_by = _assigned_by,
+        assigned_at = now(),
+        updated_at = now();
+
+      INSERT INTO public.role_audit_log (
+        profile_id, old_role, new_role, action_type, assigned_by,
+        reason, organization_id
+      ) VALUES (
+        _profile_id, NULL, role_item, 'assigned', _assigned_by,
+        'Automatic role sync based on position', profile_record.organization_id
+      );
+    END LOOP;
+  END IF;
+END;
+$function$;
+
+-- Update handle_profile_role_sync function and trigger
+CREATE OR REPLACE FUNCTION public.handle_profile_role_sync()
+RETURNS TRIGGER
+LANGUAGE PLPGSQL
+SECURITY DEFINER
+AS $function$
+BEGIN
+  PERFORM public.sync_user_roles(NEW.id);
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS sync_user_roles_on_profile_update ON public.employee_info;
+CREATE TRIGGER sync_user_roles_on_profile_update
+  AFTER INSERT OR UPDATE OF job_title, department_id, division_id, manager_id
+  ON public.employee_info
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_profile_role_sync();
+
+-- Update get_user_profile_id function
+CREATE OR REPLACE FUNCTION public.get_user_profile_id()
+RETURNS uuid
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+AS $function$
+BEGIN
+  RETURN (
+    SELECT id
+    FROM public.employee_info
+    WHERE user_id = auth.uid()
+  );
+END;
+$function$;
+
+-- Update get_direct_reports function
+CREATE OR REPLACE FUNCTION public.get_direct_reports(_profile_id UUID)
+RETURNS TABLE(profile_id UUID)
+LANGUAGE plpgsql
+SECURITY DEFINER STABLE
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT id
+  FROM public.employee_info
+  WHERE manager_id = _profile_id
+    AND organization_id = get_user_organization_id();
+END;
+$function$;
+
+-- Update get_division_employees function
+CREATE OR REPLACE FUNCTION public.get_division_employees(_profile_id UUID)
+RETURNS TABLE(profile_id UUID)
+LANGUAGE plpgsql
+SECURITY DEFINER STABLE
+AS $function$
+DECLARE
+  user_division_id UUID;
+BEGIN
+  SELECT division_id INTO user_division_id
+  FROM public.employee_info
+  WHERE id = _profile_id;
+
+  RETURN QUERY
+  SELECT id
+  FROM public.employee_info
+  WHERE division_id = user_division_id
+    AND organization_id = get_user_organization_id();
+END;
+$function$;
+
+-- Update get_current_user_roles function
+CREATE OR REPLACE FUNCTION public.get_current_user_roles()
+RETURNS TABLE(role public.app_role)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+AS $function$
+  SELECT ur.role
+  FROM public.user_roles ur
+  JOIN public.employee_info p ON p.id = ur.profile_id
+  WHERE p.user_id = auth.uid()
+    AND ur.is_active = true;
+$function$;
+
+-- Update get_suggested_appraisers function
+CREATE OR REPLACE FUNCTION get_suggested_appraisers(employee_id UUID)
+RETURNS TABLE(
+    appraiser_id UUID,
+    appraiser_name TEXT,
+    appraiser_role TEXT,
+    hierarchy_level INTEGER
+) AS $function$
+BEGIN
+    RETURN QUERY
+    WITH employee_info AS (
+        SELECT p.manager_id, p.department_id, p.division_id, p.organization_id
+        FROM public.employee_info p
+        WHERE p.id = employee_id
+    ),
+    hierarchy AS (
+        SELECT p.id, p.name, COALESCE(r.name, 'Manager') as role_name, 1 as level
+        FROM employee_info ei
+        JOIN public.employee_info p ON p.id = ei.manager_id
+        LEFT JOIN public.roles r ON r.id = p.role_id
+        WHERE p.status = 'active'
+
+        UNION ALL
+
+        SELECT dh.head_id, p.name, COALESCE(r.name, 'Department Head') as role_name, 2 as level
+        FROM employee_info ei
+        JOIN public.department_heads dh ON dh.department_id = ei.department_id
+        JOIN public.employee_info p ON p.id = dh.head_id
+        LEFT JOIN public.roles r ON r.id = p.role_id
+        WHERE p.status = 'active' AND dh.head_id != employee_id
+
+        UNION ALL
+
+        SELECT dd.director_id, p.name, COALESCE(r.name, 'Division Director') as role_name, 3 as level
+        FROM employee_info ei
+        JOIN public.division_directors dd ON dd.division_id = ei.division_id
+        JOIN public.employee_info p ON p.id = dd.director_id
+        LEFT JOIN public.roles r ON r.id = p.role_id
+        WHERE p.status = 'active' AND dd.director_id != employee_id
+    )
+    SELECT h.id, h.name, h.role_name, h.level
+    FROM hierarchy h
+    ORDER BY h.level
+    LIMIT 2;
+END;
+$function$;
+
+-- Update assign_appraisers function
+CREATE OR REPLACE FUNCTION assign_appraisers(
+    employee_id UUID,
+    appraiser_ids UUID[],
+    assigned_by UUID
+) RETURNS BOOLEAN AS $function$
+DECLARE
+    appraiser_id UUID;
+    user_org_id UUID;
+    i INTEGER := 1;
+BEGIN
+    SELECT organization_id INTO user_org_id FROM public.employee_info WHERE id = assigned_by;
+
+    DELETE FROM appraiser_assignments WHERE employee_id = assign_appraisers.employee_id;
+
+    FOREACH appraiser_id IN ARRAY appraiser_ids
+    LOOP
+        INSERT INTO appraiser_assignments (
+            employee_id,
+            appraiser_id,
+            assigned_by,
+            organization_id,
+            is_primary
+        ) VALUES (
+            assign_appraisers.employee_id,
+            appraiser_id,
+            assigned_by,
+            user_org_id,
+            i = 1
+        );
+        i := i + 1;
+    END LOOP;
+
+    RETURN TRUE;
+END;
+$function$;
+
+-- Update get_editable_employees function
+CREATE OR REPLACE FUNCTION get_editable_employees(user_id UUID)
+RETURNS TABLE(
+    employee_id UUID,
+    employee_name TEXT,
+    employee_role TEXT,
+    can_edit BOOLEAN
+) AS $function$
+BEGIN
+    RETURN QUERY
+    WITH user_info AS (
+        SELECT p.id, p.organization_id, p.department_id, p.division_id, COALESCE(r.name, 'Employee') as role_name
+        FROM public.employee_info p
+        LEFT JOIN public.roles r ON r.id = p.role_id
+        WHERE p.id = user_id
+    )
+    SELECT
+        p.id,
+        COALESCE(p.name, p.email),
+        COALESCE(r.name, 'Employee'),
+        CASE
+            WHEN ui.role_name = 'Admin' THEN TRUE
+            WHEN EXISTS (
+                SELECT 1 FROM division_directors dd
+                WHERE dd.director_id = ui.id AND dd.division_id = p.division_id
+            ) THEN TRUE
+            WHEN EXISTS (
+                SELECT 1 FROM department_heads dh
+                WHERE dh.head_id = ui.id AND dh.department_id = p.department_id
+            ) THEN TRUE
+            WHEN p.manager_id = ui.id THEN TRUE
+            WHEN p.id = ui.id THEN TRUE
+            ELSE FALSE
+        END as can_edit
+    FROM user_info ui
+    CROSS JOIN public.employee_info p
+    LEFT JOIN public.roles r ON r.id = p.role_id
+    WHERE p.organization_id = ui.organization_id
+    AND p.status = 'active';
+END;
+$function$;
+
+-- Update audit trigger
+DROP TRIGGER IF EXISTS audit_profiles_trigger ON public.profiles;
+DROP TRIGGER IF EXISTS audit_employee_info_trigger ON public.employee_info;
+CREATE TRIGGER audit_employee_info_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON public.employee_info
+  FOR EACH ROW EXECUTE FUNCTION public.audit_trigger_func();
+
+-- Update updated_at trigger
+DROP TRIGGER IF EXISTS update_profiles_updated_at ON public.profiles;
+DROP TRIGGER IF EXISTS update_employee_info_updated_at ON public.employee_info;
+CREATE TRIGGER update_employee_info_updated_at
+  BEFORE UPDATE ON public.employee_info
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+


### PR DESCRIPTION
## Summary
- rename `profiles` table to `employee_info`
- update SQL functions/triggers for new table
- adjust TypeScript queries to use `employee_info`
- regenerate Supabase types with new table name

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68801c53f930832cbe4a7603c4f07755