### PR TITLE
Add code identifiers for divisions and departments

### DIFF
--- a/src/components/admin/reports/ReportsPage.tsx
+++ b/src/components/admin/reports/ReportsPage.tsx
@@ -52,7 +52,7 @@ const ReportsPage = () => {
   const { data: divisions = [] } = useQuery({
     queryKey: ['divisions'],
     queryFn: async () => {
-      const { data } = await supabase.from('divisions').select('id, name').order('name');
+      const { data } = await supabase.from('divisions').select('id, name, code').order('name');
       return data || [];
     }
   });

--- a/src/components/onboarding/components/OrganizationalChart.tsx
+++ b/src/components/onboarding/components/OrganizationalChart.tsx
@@ -70,7 +70,7 @@ export default function OrganizationalChart({
       // Load divisions
       const { data: divisionsData, error: divisionsError } = await supabase
         .from('divisions')
-        .select('*')
+        .select('id, name, code')
         .order('name');
 
       if (divisionsError) throw divisionsError;
@@ -78,7 +78,7 @@ export default function OrganizationalChart({
       // Load departments
       const { data: departmentsData, error: departmentsError } = await supabase
         .from('departments')
-        .select('*')
+        .select('id, name, code, division_id')
         .order('name');
 
       if (departmentsError) throw departmentsError;

--- a/src/components/profile/DepartmentSelector.tsx
+++ b/src/components/profile/DepartmentSelector.tsx
@@ -48,6 +48,7 @@ export function DepartmentSelector({
         .from('departments')
         .insert({
           name: newDepartmentName.trim(),
+          code: newDepartmentName.trim().slice(0, 3).toUpperCase(),
           division_id: divisionId || null,
           organization_id: orgData
         })

--- a/src/hooks/useEmployees.ts
+++ b/src/hooks/useEmployees.ts
@@ -27,8 +27,8 @@ export const useEmployees = (options: UseEmployeesOptions = {}) => {
           status,
           created_at,
           role:roles(id, name),
-          division:divisions(id, name),
-          department:departments(id, name),
+          division:divisions(id, name, code),
+          department:departments(id, name, code),
           manager:profiles!profiles_manager_id_fkey(
             id,
             first_name,

--- a/src/hooks/useOnboardingPersistence.ts
+++ b/src/hooks/useOnboardingPersistence.ts
@@ -72,12 +72,13 @@ export const useOnboardingPersistence = () => {
         if (divisions.length > 0) {
           const divisionInserts = divisions.map(div => ({
             name: div.name,
+            code: div.name.slice(0, 3).toUpperCase(),
             organization_id: organizationId
           }));
 
           const { error: divError } = await supabase
             .from('divisions')
-            .upsert(divisionInserts, { onConflict: 'name,organization_id' });
+            .upsert(divisionInserts, { onConflict: 'code,organization_id' });
 
           if (divError) throw new Error(`Failed to save divisions: ${divError.message}`);
           operations.push('divisions');
@@ -87,13 +88,14 @@ export const useOnboardingPersistence = () => {
         if (departments.length > 0) {
           const departmentInserts = departments.map(dept => ({
             name: dept.name,
+            code: dept.name.slice(0, 3).toUpperCase(),
             organization_id: organizationId,
             division_id: null // You may want to link these properly based on your structure
           }));
 
           const { error: deptError } = await supabase
             .from('departments')
-            .upsert(departmentInserts, { onConflict: 'name,organization_id' });
+            .upsert(departmentInserts, { onConflict: 'code,organization_id' });
 
           if (deptError) throw new Error(`Failed to save departments: ${deptError.message}`);
           operations.push('departments');

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -84,8 +84,8 @@ export function useProfile() {
   const fetchOrganizationData = async () => {
     try {
       const [departmentsRes, divisionsRes, rolesRes, managersRes] = await Promise.all([
-        supabase.from('departments').select('*'),
-        supabase.from('divisions').select('*'),
+        supabase.from('departments').select('id, name, code, division_id'),
+        supabase.from('divisions').select('id, name, code'),
         supabase.from('roles').select('*'),
         supabase.from('profiles').select('id, first_name, last_name, name, job_title').neq('user_id', user?.id || '')
       ]);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -358,6 +358,7 @@ export type Database = {
           division_id: string | null
           id: string
           name: string
+          code: string
           organization_id: string
         }
         Insert: {
@@ -365,6 +366,7 @@ export type Database = {
           division_id?: string | null
           id?: string
           name: string
+          code: string
           organization_id: string
         }
         Update: {
@@ -372,6 +374,7 @@ export type Database = {
           division_id?: string | null
           id?: string
           name?: string
+          code?: string
           organization_id?: string
         }
         Relationships: [
@@ -474,18 +477,21 @@ export type Database = {
           created_at: string
           id: string
           name: string
+          code: string
           organization_id: string
         }
         Insert: {
           created_at?: string
           id?: string
           name: string
+          code: string
           organization_id: string
         }
         Update: {
           created_at?: string
           id?: string
           name?: string
+          code?: string
           organization_id?: string
         }
         Relationships: [

--- a/supabase/functions/import-employees/index.ts
+++ b/supabase/functions/import-employees/index.ts
@@ -120,8 +120,12 @@ serve(async (req) => {
       const { data: insertedDivisions, error: divisionError } = await supabaseAdmin
         .from('divisions')
         .upsert(
-          divisions.map(name => ({ name, organization_id: organizationId })),
-          { onConflict: 'name,organization_id' }
+          divisions.map(name => ({
+            name,
+            code: name.slice(0, 3).toUpperCase(),
+            organization_id: organizationId
+          })),
+          { onConflict: 'code,organization_id' }
         )
         .select('id, name')
 
@@ -141,12 +145,13 @@ serve(async (req) => {
       const { data: insertedDepartments, error: departmentError } = await supabaseAdmin
         .from('departments')
         .upsert(
-          departments.map(name => ({ 
-            name, 
+          departments.map(name => ({
+            name,
+            code: name.slice(0, 3).toUpperCase(),
             organization_id: organizationId,
             division_id: null
           })),
-          { onConflict: 'name,organization_id' }
+          { onConflict: 'code,organization_id' }
         )
         .select('id, name')
 

--- a/supabase/migrations/20250714163422-d75d4747-7220-4fb5-880e-0709c343090a.sql
+++ b/supabase/migrations/20250714163422-d75d4747-7220-4fb5-880e-0709c343090a.sql
@@ -24,6 +24,7 @@ CREATE TABLE public.divisions (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
+  code TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 
@@ -33,6 +34,7 @@ CREATE TABLE public.departments (
   organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
   division_id UUID REFERENCES public.divisions(id),
   name TEXT NOT NULL,
+  code TEXT NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
 );
 

--- a/supabase/migrations/20250714203722-9314fef5-ae5e-473b-80bd-8782ffc1e1da.sql
+++ b/supabase/migrations/20250714203722-9314fef5-ae5e-473b-80bd-8782ffc1e1da.sql
@@ -24,28 +24,28 @@ BEGIN
     SELECT id INTO org_id FROM organizations WHERE name = 'Default Organization';
     
     -- Create all PJIAE divisions
-    INSERT INTO divisions (name, organization_id) VALUES
-        ('Executive', org_id),
-        ('Technical', org_id),
-        ('Finance', org_id),
-        ('Operations', org_id),
-        ('Human Resources', org_id),
-        ('Engineering', org_id),
-        ('Commercial', org_id),
-        ('Security', org_id),
-        ('Quality Assurance', org_id)
-    ON CONFLICT (name, organization_id) DO NOTHING;
+    INSERT INTO divisions (name, code, organization_id) VALUES
+        ('Executive', 'EXE', org_id),
+        ('Technical', 'TEC', org_id),
+        ('Finance', 'FIN', org_id),
+        ('Operations', 'OPS', org_id),
+        ('Human Resources', 'HRS', org_id),
+        ('Engineering', 'ENG', org_id),
+        ('Commercial', 'COM', org_id),
+        ('Security', 'SEC', org_id),
+        ('Quality Assurance', 'QAS', org_id)
+    ON CONFLICT (organization_id, code) DO NOTHING;
     
     -- Get division IDs
-    SELECT id INTO executive_div_id FROM divisions WHERE name = 'Executive' AND organization_id = org_id;
-    SELECT id INTO technical_div_id FROM divisions WHERE name = 'Technical' AND organization_id = org_id;
-    SELECT id INTO finance_div_id FROM divisions WHERE name = 'Finance' AND organization_id = org_id;
-    SELECT id INTO operations_div_id FROM divisions WHERE name = 'Operations' AND organization_id = org_id;
-    SELECT id INTO hr_div_id FROM divisions WHERE name = 'Human Resources' AND organization_id = org_id;
-    SELECT id INTO engineering_div_id FROM divisions WHERE name = 'Engineering' AND organization_id = org_id;
-    SELECT id INTO commercial_div_id FROM divisions WHERE name = 'Commercial' AND organization_id = org_id;
-    SELECT id INTO security_div_id FROM divisions WHERE name = 'Security' AND organization_id = org_id;
-    SELECT id INTO qa_div_id FROM divisions WHERE name = 'Quality Assurance' AND organization_id = org_id;
+    SELECT id INTO executive_div_id FROM divisions WHERE code = 'EXE' AND organization_id = org_id;
+    SELECT id INTO technical_div_id FROM divisions WHERE code = 'TEC' AND organization_id = org_id;
+    SELECT id INTO finance_div_id FROM divisions WHERE code = 'FIN' AND organization_id = org_id;
+    SELECT id INTO operations_div_id FROM divisions WHERE code = 'OPS' AND organization_id = org_id;
+    SELECT id INTO hr_div_id FROM divisions WHERE code = 'HRS' AND organization_id = org_id;
+    SELECT id INTO engineering_div_id FROM divisions WHERE code = 'ENG' AND organization_id = org_id;
+    SELECT id INTO commercial_div_id FROM divisions WHERE code = 'COM' AND organization_id = org_id;
+    SELECT id INTO security_div_id FROM divisions WHERE code = 'SEC' AND organization_id = org_id;
+    SELECT id INTO qa_div_id FROM divisions WHERE code = 'QAS' AND organization_id = org_id;
     
     -- Insert/Update Executive departments
     INSERT INTO departments (name, division_id, organization_id) VALUES
@@ -55,25 +55,25 @@ BEGIN
     ON CONFLICT (name, organization_id) DO UPDATE SET division_id = EXCLUDED.division_id;
     
     -- Insert/Update all PJIAE departments
-    INSERT INTO departments (name, division_id, organization_id) VALUES
-        ('Finance', finance_div_id, org_id),
-        ('Accounting', finance_div_id, org_id),
-        ('Budget & Planning', finance_div_id, org_id),
-        ('Operations', operations_div_id, org_id),
-        ('Maintenance', operations_div_id, org_id),
-        ('Ground Support', operations_div_id, org_id),
-        ('Human Resources', hr_div_id, org_id),
-        ('Training & Development', hr_div_id, org_id),
-        ('Engineering', engineering_div_id, org_id),
-        ('Project Management Unit', technical_div_id, org_id),
-        ('IT Services', technical_div_id, org_id),
-        ('Commercial', commercial_div_id, org_id),
-        ('Marketing', commercial_div_id, org_id),
-        ('Customer Service', commercial_div_id, org_id),
-        ('Security', security_div_id, org_id),
-        ('Safety & Compliance', security_div_id, org_id),
-        ('Quality Assurance', qa_div_id, org_id),
-        ('Audit', qa_div_id, org_id)
+    INSERT INTO departments (name, code, division_id, organization_id) VALUES
+        ('Finance', 'FIN', finance_div_id, org_id),
+        ('Accounting', 'ACC', finance_div_id, org_id),
+        ('Budget & Planning', 'BPL', finance_div_id, org_id),
+        ('Operations', 'OPS', operations_div_id, org_id),
+        ('Maintenance', 'MNT', operations_div_id, org_id),
+        ('Ground Support', 'GRD', operations_div_id, org_id),
+        ('Human Resources', 'HRS', hr_div_id, org_id),
+        ('Training & Development', 'TRD', hr_div_id, org_id),
+        ('Engineering', 'ENG', engineering_div_id, org_id),
+        ('Project Management Unit', 'PMU', technical_div_id, org_id),
+        ('IT Services', 'ITS', technical_div_id, org_id),
+        ('Commercial', 'COM', commercial_div_id, org_id),
+        ('Marketing', 'MKT', commercial_div_id, org_id),
+        ('Customer Service', 'CUS', commercial_div_id, org_id),
+        ('Security', 'SEC', security_div_id, org_id),
+        ('Safety & Compliance', 'SAC', security_div_id, org_id),
+        ('Quality Assurance', 'QAS', qa_div_id, org_id),
+        ('Audit', 'AUD', qa_div_id, org_id)
     ON CONFLICT (name, organization_id) DO UPDATE SET division_id = EXCLUDED.division_id;
 END $$;
 

--- a/supabase/migrations/20250715165824-8125fb81-4947-4df7-bf67-3d0e32e0c6e7.sql
+++ b/supabase/migrations/20250715165824-8125fb81-4947-4df7-bf67-3d0e32e0c6e7.sql
@@ -21,61 +21,61 @@ SELECT 'Employee', 'Regular Employee', id FROM public.organizations WHERE name =
 ON CONFLICT DO NOTHING;
 
 -- Create sample divisions
-INSERT INTO public.divisions (name, organization_id) 
-SELECT 'Operations', id FROM public.organizations WHERE name = 'Default Organization'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.divisions (name, code, organization_id)
+SELECT 'Operations', 'OPS', id FROM public.organizations WHERE name = 'Default Organization'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.divisions (name, organization_id) 
-SELECT 'Human Resources', id FROM public.organizations WHERE name = 'Default Organization'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.divisions (name, code, organization_id)
+SELECT 'Human Resources', 'HRS', id FROM public.organizations WHERE name = 'Default Organization'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.divisions (name, organization_id) 
-SELECT 'Finance', id FROM public.organizations WHERE name = 'Default Organization'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.divisions (name, code, organization_id)
+SELECT 'Finance', 'FIN', id FROM public.organizations WHERE name = 'Default Organization'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.divisions (name, organization_id) 
-SELECT 'Information Technology', id FROM public.organizations WHERE name = 'Default Organization'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.divisions (name, code, organization_id)
+SELECT 'Information Technology', 'TEC', id FROM public.organizations WHERE name = 'Default Organization'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
 -- Create sample departments
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Sales', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Operations'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Sales', 'SAL', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'OPS'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Marketing', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Operations'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Marketing', 'MKT', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'OPS'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Recruitment', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Human Resources'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Recruitment', 'REC', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'HRS'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Payroll', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Human Resources'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Payroll', 'PAY', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'HRS'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Accounting', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Finance'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Accounting', 'ACC', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'FIN'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Development', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Information Technology'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Development', 'DEV', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'TEC'
+ON CONFLICT (organization_id, code) DO NOTHING;
 
-INSERT INTO public.departments (name, division_id, organization_id) 
-SELECT 'Support', d.id, d.organization_id 
-FROM public.divisions d 
-WHERE d.name = 'Information Technology'
-ON CONFLICT DO NOTHING;
+INSERT INTO public.departments (name, code, division_id, organization_id)
+SELECT 'Support', 'SUP', d.id, d.organization_id
+FROM public.divisions d
+WHERE d.code = 'TEC'
+ON CONFLICT (organization_id, code) DO NOTHING;

--- a/supabase/migrations/20250716153138-87ad2940-d9ee-44c2-a15f-2cd71847d7e7.sql
+++ b/supabase/migrations/20250716153138-87ad2940-d9ee-44c2-a15f-2cd71847d7e7.sql
@@ -22,9 +22,13 @@ WHERE id NOT IN (
   ORDER BY name, organization_id, created_at ASC
 );
 
-ALTER TABLE public.divisions 
-ADD CONSTRAINT divisions_name_organization_unique 
+ALTER TABLE public.divisions
+ADD CONSTRAINT divisions_name_organization_unique
 UNIQUE (name, organization_id);
+
+ALTER TABLE public.divisions
+ADD CONSTRAINT divisions_code_organization_unique
+UNIQUE (organization_id, code);
 
 -- Add unique constraint to departments table for (name, organization_id)
 -- First, remove any existing duplicates by keeping the first occurrence
@@ -35,6 +39,10 @@ WHERE id NOT IN (
   ORDER BY name, organization_id, created_at ASC
 );
 
-ALTER TABLE public.departments 
-ADD CONSTRAINT departments_name_organization_unique 
+ALTER TABLE public.departments
+ADD CONSTRAINT departments_name_organization_unique
 UNIQUE (name, organization_id);
+
+ALTER TABLE public.departments
+ADD CONSTRAINT departments_code_organization_unique
+UNIQUE (organization_id, code);


### PR DESCRIPTION
## Summary
- add `code` column to divisions and departments
- insert codes in seed migrations and enforce `(organization_id, code)` uniqueness
- surface `code` in generated Supabase types
- upsert divisions/departments by code during onboarding and CSV imports
- expose code fields in queries and selectors

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68801c5061fc832c929bb511a1a2fdb1