### PR TITLE
Implement soft delete helpers

### DIFF
--- a/supabase/migrations/20250721165000-7b843d4f-32a7-45d3-b044-d0ab0892a069.sql
+++ b/supabase/migrations/20250721165000-7b843d4f-32a7-45d3-b044-d0ab0892a069.sql
@@ -1,0 +1,52 @@
+-- Add soft delete helper functions
+
+-- Function to mark a record as soft deleted
+CREATE OR REPLACE FUNCTION public.soft_delete_record(_table_name text, _record_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  _result boolean := false;
+  _query text;
+BEGIN
+  _query := format('UPDATE public.%I SET deleted_at = now(), updated_at = now() WHERE id = $1 AND deleted_at IS NULL', _table_name);
+  EXECUTE _query USING _record_id;
+  GET DIAGNOSTICS _result = ROW_COUNT;
+  RETURN _result > 0;
+END;
+$$;
+
+-- Function to restore a previously soft deleted record
+CREATE OR REPLACE FUNCTION public.restore_record(_table_name text, _record_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  _result boolean := false;
+  _query text;
+BEGIN
+  _query := format('UPDATE public.%I SET deleted_at = NULL, updated_at = now() WHERE id = $1 AND deleted_at IS NOT NULL', _table_name);
+  EXECUTE _query USING _record_id;
+  GET DIAGNOSTICS _result = ROW_COUNT;
+  RETURN _result > 0;
+END;
+$$;
+
+-- Permanently delete records that were soft deleted more than _days_old days ago
+CREATE OR REPLACE FUNCTION public.permanent_delete_old_records(_table_name text, _days_old integer DEFAULT 90)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  _deleted integer := 0;
+  _query text;
+BEGIN
+  _query := format('DELETE FROM public.%I WHERE deleted_at IS NOT NULL AND deleted_at < now() - ($1 || '' days'')::interval', _table_name);
+  EXECUTE _query USING _days_old;
+  GET DIAGNOSTICS _deleted = ROW_COUNT;
+  RETURN _deleted;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add SQL migration for generic `soft_delete_record`, `restore_record` and `permanent_delete_old_records` functions

## Testing
- `npm run lint` *(fails: Unexpected any, prefer const, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68801c4b0988832c8b4d826f4140116a