### PR TITLE
Add role audit log migration

### DIFF
--- a/supabase/migrations/20250721160500-dcbf1524-9ccb-4f99-919b-60e2553b8d92.sql
+++ b/supabase/migrations/20250721160500-dcbf1524-9ccb-4f99-919b-60e2553b8d92.sql
@@ -1,0 +1,13 @@
+-- Create role_audit_log table to track role assignments and changes
+CREATE TABLE public.role_audit_log (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  profile_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  old_role public.app_role,
+  new_role public.app_role,
+  action_type TEXT NOT NULL,
+  assigned_by UUID REFERENCES public.profiles(id),
+  reason TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- add `public.role_audit_log` table migration

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68801c4a4458832c9cb3af6e9faa0ebf