### PR TITLE
Add organization store and load user organization

### DIFF
--- a/src/components/admin/AdminOrgManagement.tsx
+++ b/src/components/admin/AdminOrgManagement.tsx
@@ -18,6 +18,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { StatCard } from "@/components/ui/stat-card";
 import OrganizationalChart from "../onboarding/components/OrganizationalChart";
 import AppraiserAssignmentModal from "../onboarding/components/AppraiserAssignmentModal";
+import { useOrganizationStore } from "@/stores/organizationStore";
 
 interface Employee {
   id: string;
@@ -32,6 +33,7 @@ interface Employee {
 export default function AdminOrgManagement() {
   const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
   const [showAppraiserModal, setShowAppraiserModal] = useState(false);
+  const { name: organizationName } = useOrganizationStore();
 
   const handleAssignAppraiser = (employee: Employee) => {
     setSelectedEmployee(employee);
@@ -80,7 +82,7 @@ export default function AdminOrgManagement() {
     <div className="space-y-6">
       <PageHeader
         title="Organization Management"
-        description="Manage PJIAE's organizational structure, roles, and reporting relationships"
+        description={`Manage ${organizationName || 'your organization'}'s organizational structure, roles, and reporting relationships`}
       >
         <Button>
           <Settings className="w-4 h-4 mr-2" />
@@ -119,7 +121,7 @@ export default function AdminOrgManagement() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Building2 className="w-5 h-5" />
-                PJIAE Organizational Structure
+                {organizationName || 'Organization'} Organizational Structure
               </CardTitle>
               <CardDescription>
                 Interactive view of the airport's complete organizational hierarchy

--- a/src/components/admin/organization/OrganizationPage.tsx
+++ b/src/components/admin/organization/OrganizationPage.tsx
@@ -3,11 +3,19 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Building2, Users, MapPin, Mail, Phone, Globe, Plus, Edit2 } from "lucide-react";
+import { useOrganizationStore } from "@/stores/organizationStore";
 
 const OrganizationPage = () => {
+  const { name: organizationName } = useOrganizationStore();
+  const orgInitials = (organizationName || 'SG')
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
   // TODO: Load organization data from database
   const organizationData = {
-    name: "Smartgoals 360 Enterprise",
+    name: organizationName || "Smartgoals 360 Enterprise",
     logo: null,
     address: {
       street: "123 Business Avenue",
@@ -66,7 +74,7 @@ const OrganizationPage = () => {
           <CardContent className="space-y-4">
             <div className="flex items-center gap-4">
               <div className="h-16 w-16 bg-primary rounded-lg flex items-center justify-center">
-                <span className="text-white font-bold text-xl">SG</span>
+                <span className="text-white font-bold text-xl">{orgInitials}</span>
               </div>
               <div>
                 <h3 className="font-semibold text-lg">{organizationData.name}</h3>

--- a/src/components/admin/settings/SettingsPage.tsx
+++ b/src/components/admin/settings/SettingsPage.tsx
@@ -2,8 +2,19 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Settings, Palette, Database, Globe, Shield, Save } from "lucide-react";
+import { useOrganizationStore } from "@/stores/organizationStore";
 
 const SettingsPage = () => {
+  const { name: organizationName } = useOrganizationStore();
+  const orgInitials = (organizationName || 'SG')
+    .split(/\s+/)
+    .map(w => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+  const organizationDomain = organizationName
+    ? `company.${organizationName.toLowerCase().replace(/\s+/g, '')}.com`
+    : 'company.smartgoals360.com';
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -35,7 +46,7 @@ const SettingsPage = () => {
               <div className="text-sm font-medium">Organization Logo</div>
               <div className="border-2 border-dashed border-muted-foreground/25 rounded-lg p-6 text-center">
                 <div className="mx-auto h-12 w-12 bg-primary rounded-lg flex items-center justify-center mb-3">
-                  <span className="text-white font-bold">SG</span>
+                  <span className="text-white font-bold">{orgInitials}</span>
                 </div>
                 <p className="text-sm text-muted-foreground">Click to upload new logo</p>
               </div>
@@ -61,13 +72,13 @@ const SettingsPage = () => {
               <div>
                 <label className="text-sm font-medium">Organization Name</label>
                 <div className="mt-1 p-2 border rounded-md bg-muted">
-                  Smartgoals 360 Enterprise
+                  {organizationName || 'Smartgoals 360 Enterprise'}
                 </div>
               </div>
               <div>
                 <label className="text-sm font-medium">Domain</label>
                 <div className="mt-1 p-2 border rounded-md bg-muted">
-                  company.smartgoals360.com
+                  {organizationDomain}
                 </div>
               </div>
               <Button variant="outline" className="w-full">

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 import { DashboardLayout } from '../DashboardLayout'
 import { useAuth } from '@/hooks/useAuth'
+import { useCurrentOrganization } from '@/hooks/useCurrentOrganization'
 
 interface Breadcrumb {
   label: string
@@ -95,6 +96,7 @@ const generateBreadcrumbs = (pathname: string): Breadcrumb[] => {
 export function AppLayout({ children }: AppLayoutProps) {
   const location = useLocation()
   const { user } = useAuth()
+  useCurrentOrganization()
   
   const shouldShowSidebar = useMemo(() => {
     // Don't show sidebar for public routes

--- a/src/hooks/useCurrentOrganization.ts
+++ b/src/hooks/useCurrentOrganization.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from './useAuth';
+import { useOrganizationStore } from '@/stores/organizationStore';
+
+export function useCurrentOrganization() {
+  const { user, loading: authLoading } = useAuth();
+  const { setOrganization, clearOrganization } = useOrganizationStore();
+
+  useEffect(() => {
+    const loadOrganization = async () => {
+      if (!user) {
+        clearOrganization();
+        return;
+      }
+
+      const { data, error } = await supabase
+        .from('employee_info')
+        .select('organization_id, organizations(name)')
+        .eq('user_id', user.id)
+        .single();
+
+      if (error) {
+        console.error('Failed to load organization:', error);
+        clearOrganization();
+        return;
+      }
+
+      setOrganization(data.organization_id, data.organizations?.name ?? null);
+    };
+
+    if (!authLoading) {
+      loadOrganization();
+    }
+  }, [user, authLoading, setOrganization, clearOrganization]);
+
+  return useOrganizationStore();
+}

--- a/src/stores/organizationStore.ts
+++ b/src/stores/organizationStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface OrganizationState {
+  id: string | null;
+  name: string | null;
+  setOrganization: (id: string | null, name: string | null) => void;
+  clearOrganization: () => void;
+}
+
+export const useOrganizationStore = create<OrganizationState>()(
+  persist(
+    (set) => ({
+      id: null,
+      name: null,
+      setOrganization: (id, name) => set({ id, name }),
+      clearOrganization: () => set({ id: null, name: null }),
+    }),
+    { name: 'active-organization' }
+  )
+);


### PR DESCRIPTION
## Summary
- add Zustand `organizationStore` to hold active org info
- create `useCurrentOrganization` hook to fetch org after login
- use `useCurrentOrganization` in `AppLayout`
- display active org name in admin pages

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881280e593c832ca5a7bedd8404a9bb