### PR TITLE
Switch to Clerk for user management

### DIFF
--- a/supabase/functions/import-employees/index.ts
+++ b/supabase/functions/import-employees/index.ts
@@ -151,6 +151,7 @@ serve(async (req) => {
       throw new Error(orgResult.error)
     }
     const organizationId = orgResult.organizationId!
+    const clerkOrganizationId = orgResult.clerkOrganizationId!
 
     // Create divisions and departments
     const { divisionMap, departmentMap } = await databaseService.createDivisionsAndDepartments(people, organizationId)
@@ -159,6 +160,7 @@ serve(async (req) => {
     const databaseContext = {
       supabaseAdmin,
       organizationId,
+      clerkOrganizationId,
       divisionMap,
       departmentMap
     }
@@ -181,7 +183,7 @@ serve(async (req) => {
     }
 
     // Update admin profile
-    await databaseService.updateAdminProfile(adminInfo, user.id, organizationId)
+    await databaseService.updateAdminProfile(adminInfo, user.id, organizationId, clerkOrganizationId)
 
     // Prepare final result
     const result: ImportResult = {

--- a/supabase/functions/import-employees/types.ts
+++ b/supabase/functions/import-employees/types.ts
@@ -52,6 +52,7 @@ export interface SecurityContext {
 export interface DatabaseContext {
   supabaseAdmin: any
   organizationId: string
+  clerkOrganizationId: string
   divisionMap: Record<string, string>
   departmentMap: Record<string, string>
 }


### PR DESCRIPTION
## Summary
- use Clerk backend API for creating users
- manage memberships via Clerk organizations
- keep Supabase for division, department and profile data

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68847437a808832c824232e25129069a