### PR TITLE
Define DebugInfo interface

### DIFF
--- a/src/components/debug/ImportDebugPanel.tsx
+++ b/src/components/debug/ImportDebugPanel.tsx
@@ -1,16 +1,36 @@
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
 
 interface ImportDebugPanelProps {
   isVisible?: boolean;
 }
 
+interface ValidationError {
+  path?: string[];
+  field?: string;
+  message?: string;
+  code?: string;
+}
+
+interface DebugInfo {
+  user?: unknown;
+  orgId?: unknown;
+  profileError?: string;
+  organizations?: unknown;
+  orgError?: string;
+  testData?: unknown;
+  result?: unknown;
+  error?: string;
+  validationErrors?: ValidationError[] | null;
+  timestamp: string;
+}
+
 export const ImportDebugPanel = ({ isVisible = false }: ImportDebugPanelProps) => {
-  const [debugInfo, setDebugInfo] = useState<any>(null);
+  const [debugInfo, setDebugInfo] = useState<DebugInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
 


### PR DESCRIPTION
## Summary
- add `ValidationError` and `DebugInfo` interfaces
- use `DebugInfo | null` in `ImportDebugPanel`

## Testing
- `npm run lint` *(fails: typescript resolver errors)*
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba9e3ac58832ca41127722af36c87