### PR TITLE
Rename Sonner toaster alias

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { ProfilePage } from "@/components/profile/ProfilePage";
-import { Toaster as Sonner } from "@/components/ui/sonner";
+import { Toaster as SonnerToaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
@@ -61,7 +61,7 @@ const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <Toaster />
-      <Sonner />
+      <SonnerToaster />
       <BrowserRouter>
         <DemoModeProvider>
           <AuthDebugPanel />


### PR DESCRIPTION
## Summary
- rename the alias for the Sonner toaster import
- update JSX usage accordingly

## Testing
- `npm test --silent` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688ba9de92dc832cbd59ccb4a271c6b6