### PR TITLE
Wrap dashboard stats in useMemo

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from "react-router-dom";
 import { usePermissions } from "@/hooks/usePermissions";
 import { DemoModeBanner } from "@/components/ui/demo-mode-banner";
 import { useDemoMode } from "@/contexts/DemoModeContext";
+import { useMemo } from "react";
 
 const Dashboard = () => {
   const navigate = useNavigate();
@@ -49,36 +50,47 @@ const Dashboard = () => {
   const totalEmployees = employees?.length || 0;
   const activeEmployees = employees?.filter(emp => emp.status === 'active').length || 0;
   
-  const stats = [
-    {
-      title: "Active Appraisals",
-      value: appraisalsLoading ? "..." : appraisalsData?.toString() || "0",
-      description: "In progress",
-      icon: FileText,
-      iconColor: "text-blue-600"
-    },
-    {
-      title: "Team Members",
-      value: employeesLoading ? "..." : activeEmployees.toString(),
-      description: "Active employees",
-      icon: Users,
-      iconColor: "text-green-600"
-    },
-    {
-      title: "Total Goals",
-      value: goalsLoading ? "..." : goalsData?.toString() || "0",
-      description: "Created goals",
-      icon: TrendingUp,
-      iconColor: "text-purple-600"
-    },
-    {
-      title: "All Employees",
-      value: employeesLoading ? "..." : totalEmployees.toString(),
-      description: "Total in system",
-      icon: Calendar,
-      iconColor: "text-orange-600"
-    }
-  ];
+  const stats = useMemo(
+    () => [
+      {
+        title: "Active Appraisals",
+        value: appraisalsLoading ? "..." : appraisalsData?.toString() || "0",
+        description: "In progress",
+        icon: FileText,
+        iconColor: "text-blue-600",
+      },
+      {
+        title: "Team Members",
+        value: employeesLoading ? "..." : activeEmployees.toString(),
+        description: "Active employees",
+        icon: Users,
+        iconColor: "text-green-600",
+      },
+      {
+        title: "Total Goals",
+        value: goalsLoading ? "..." : goalsData?.toString() || "0",
+        description: "Created goals",
+        icon: TrendingUp,
+        iconColor: "text-purple-600",
+      },
+      {
+        title: "All Employees",
+        value: employeesLoading ? "..." : totalEmployees.toString(),
+        description: "Total in system",
+        icon: Calendar,
+        iconColor: "text-orange-600",
+      },
+    ],
+    [
+      appraisalsLoading,
+      appraisalsData,
+      employeesLoading,
+      activeEmployees,
+      goalsLoading,
+      goalsData,
+      totalEmployees,
+    ],
+  );
 
   return (
     <div className="space-y-4 sm:space-y-6">

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -11,6 +11,7 @@ import { ActivityFeed } from "@/components/dashboard/ActivityFeed";
 import { useNavigate } from "react-router-dom";
 import { SystemHealthMetrics } from "./SystemHealthMetrics";
 import { DemoModeBanner } from "@/components/ui/demo-mode-banner";
+import { useMemo } from "react";
 
 const AdminDashboard = () => {
   const navigate = useNavigate();
@@ -59,36 +60,48 @@ const AdminDashboard = () => {
   const totalEmployees = employees?.length || 0;
   const activeEmployees = employees?.filter(emp => emp.status === 'active').length || 0;
   
-  const stats = [
-    {
-      title: "Total Appraisals",
-      value: appraisalsLoading ? "..." : appraisalsData?.toString() || "0",
-      description: "All appraisals",
-      icon: FileText,
-      iconColor: "text-blue-600"
-    },
-    {
-      title: "Active Employees",
-      value: employeesLoading ? "..." : activeEmployees.toString(),
-      description: "Currently employed",
-      icon: Users,
-      iconColor: "text-green-600"
-    },
-    {
-      title: "Total Goals",
-      value: goalsLoading ? "..." : goalsData?.toString() || "0",
-      description: "Organization goals",
-      icon: TrendingUp,
-      iconColor: "text-purple-600"
-    },
-    {
-      title: "Overdue Items",
-      value: overdueLoading ? "..." : overdueData?.toString() || "0",
-      description: "Requires attention",
-      icon: AlertTriangle,
-      iconColor: "text-red-600"
-    }
-  ];
+  const stats = useMemo(
+    () => [
+      {
+        title: "Total Appraisals",
+        value: appraisalsLoading ? "..." : appraisalsData?.toString() || "0",
+        description: "All appraisals",
+        icon: FileText,
+        iconColor: "text-blue-600",
+      },
+      {
+        title: "Active Employees",
+        value: employeesLoading ? "..." : activeEmployees.toString(),
+        description: "Currently employed",
+        icon: Users,
+        iconColor: "text-green-600",
+      },
+      {
+        title: "Total Goals",
+        value: goalsLoading ? "..." : goalsData?.toString() || "0",
+        description: "Organization goals",
+        icon: TrendingUp,
+        iconColor: "text-purple-600",
+      },
+      {
+        title: "Overdue Items",
+        value: overdueLoading ? "..." : overdueData?.toString() || "0",
+        description: "Requires attention",
+        icon: AlertTriangle,
+        iconColor: "text-red-600",
+      },
+    ],
+    [
+      appraisalsLoading,
+      appraisalsData,
+      employeesLoading,
+      activeEmployees,
+      goalsLoading,
+      goalsData,
+      overdueLoading,
+      overdueData,
+    ],
+  );
 
   return (
     <div className="space-y-4 sm:space-y-6">

--- a/src/components/admin/employees/EmployeeImportPage.tsx
+++ b/src/components/admin/employees/EmployeeImportPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Users, Upload, FileText, CheckCircle, ArrowLeft, ArrowRight, AlertTriangle, Mail } from "lucide-react";
@@ -281,20 +281,30 @@ const EmployeeImportPage = () => {
     setCurrentStep('upload');
   };
 
-  const stats = [
-    {
-      title: "Ready to Import",
-      value: employeesToImport.length.toString(),
-      description: "Employees processed",
-      icon: Users
-    },
-    {
-      title: "Current Step",
-      value: currentStep === 'upload' ? '1' : currentStep === 'mapping' ? '2' : currentStep === 'preview' ? '3' : '4',
-      description: "of 4 steps",
-      icon: FileText
-    }
-  ];
+  const stats = useMemo(
+    () => [
+      {
+        title: "Ready to Import",
+        value: employeesToImport.length.toString(),
+        description: "Employees processed",
+        icon: Users,
+      },
+      {
+        title: "Current Step",
+        value:
+          currentStep === "upload"
+            ? "1"
+            : currentStep === "mapping"
+              ? "2"
+              : currentStep === "preview"
+                ? "3"
+                : "4",
+        description: "of 4 steps",
+        icon: FileText,
+      },
+    ],
+    [employeesToImport.length, currentStep],
+  );
 
   // Show import results if available
   if (importResult && (importResult.imported > 0 || importResult.failed > 0)) {


### PR DESCRIPTION
## Summary
- memoize `stats` arrays across dashboard components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bb00e3798832ca1a117830cc3ca09