### PR TITLE
Ensure role assignments and redirect when none

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -12,7 +12,7 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const { isAuthenticated, loading } = useAuth();
-  const { loading: permissionsLoading } = usePermissions();
+  const { roles, loading: permissionsLoading } = usePermissions();
   const navigate = useNavigate();
   
   // Handle automatic profile claiming for invited employees
@@ -23,6 +23,12 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
       navigate("/log-in");
     }
   }, [isAuthenticated, loading, navigate]);
+
+  useEffect(() => {
+    if (!permissionsLoading && isAuthenticated && roles.length === 0) {
+      navigate("/unauthorized");
+    }
+  }, [permissionsLoading, isAuthenticated, roles, navigate]);
 
   if (loading || permissionsLoading) {
     return <RouteLoader />;

--- a/src/hooks/__tests__/useOnboardingStatus.test.ts
+++ b/src/hooks/__tests__/useOnboardingStatus.test.ts
@@ -1,0 +1,58 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Mock useAuth to provide a user
+vi.mock("../useAuth", () => ({
+  useAuth: () => ({ user: { id: "user-1" } })
+}));
+
+const insertMock = vi.fn().mockResolvedValue({ error: null });
+const updateEqMock = vi.fn().mockResolvedValue({ error: null });
+const updateMock = vi.fn(() => ({ eq: updateEqMock }));
+const maybeSingleMock = vi
+  .fn()
+  .mockResolvedValue({ data: { id: "profile-1", organization_id: "org-1" }, error: null });
+const eqMock = vi.fn(() => ({ maybeSingle: maybeSingleMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock }));
+
+// Mock Supabase client
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: (table: string) => {
+      if (table === "employee_info") {
+        return {
+          select: selectMock,
+          update: updateMock
+        } as any;
+      }
+      if (table === "user_roles") {
+        return {
+          insert: insertMock
+        } as any;
+      }
+      return {} as any;
+    }
+  }
+}));
+
+import { useOnboardingStatus } from "../useOnboardingStatus";
+
+describe("markOnboardingComplete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("inserts admin role for current user", async () => {
+    const { result } = renderHook(() => useOnboardingStatus());
+
+    await act(async () => {
+      await result.current.markOnboardingComplete();
+    });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      user_id: "user-1",
+      role: "admin",
+      organization_id: "org-1"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add redirect in `ProtectedRoute` when user has no role
- test admin role assignment with Supabase mocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be2019920832c8e9c4d347424595d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user redirection by ensuring authenticated users without roles are now redirected to the unauthorized page after permissions finish loading.

* **Tests**
  * Added tests for onboarding status functionality, specifically verifying that onboarding completion correctly assigns an admin role to the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->