### PR TITLE
Update breadcrumbs to be role-aware

### DIFF
--- a/src/components/appraisals/ReviewAndSignOffStep.tsx
+++ b/src/components/appraisals/ReviewAndSignOffStep.tsx
@@ -4,19 +4,52 @@ import * as React from "react";
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { Signature, CheckCircle, Edit, Mail, Info, ArrowLeft, Save, Star, FileText, Home, ChevronRight } from "lucide-react";
+import {
+  Signature,
+  CheckCircle,
+  Edit,
+  Mail,
+  Info,
+  ArrowLeft,
+  Save,
+  Star,
+  FileText,
+  Home,
+  ChevronRight,
+} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 import DigitalSignatureModal from "./DigitalSignatureModal";
 
 export interface Goal {
@@ -40,7 +73,7 @@ export interface AppraisalData {
   goals: Goal[];
   competencies: Competency[];
   overallRating?: number;
-  status: 'draft' | 'with_second_appraiser' | 'awaiting_employee' | 'complete';
+  status: "draft" | "with_second_appraiser" | "awaiting_employee" | "complete";
   signatures: {
     appraiser?: string;
     secondAppraiser?: string;
@@ -70,20 +103,29 @@ export interface ReviewAndSignOffStepProps {
 }
 
 const getRatingCategory = (rating: number) => {
-  if (rating >= 4.5) return { label: "Exceptional", color: "bg-green-500", textColor: "text-green-700" };
-  if (rating >= 3.5) return { label: "Exceeds Expectations", color: "bg-blue-500", textColor: "text-blue-700" };
-  if (rating >= 2.5) return { label: "Meets Expectations", color: "bg-yellow-500", textColor: "text-yellow-700" };
-  if (rating >= 1.5) return { label: "Below Expectations", color: "bg-orange-500", textColor: "text-orange-700" };
+  if (rating >= 4.5)
+    return { label: "Exceptional", color: "bg-green-500", textColor: "text-green-700" };
+  if (rating >= 3.5)
+    return { label: "Exceeds Expectations", color: "bg-blue-500", textColor: "text-blue-700" };
+  if (rating >= 2.5)
+    return { label: "Meets Expectations", color: "bg-yellow-500", textColor: "text-yellow-700" };
+  if (rating >= 1.5)
+    return { label: "Below Expectations", color: "bg-orange-500", textColor: "text-orange-700" };
   return { label: "Unsatisfactory", color: "bg-red-500", textColor: "text-red-700" };
 };
 
 const getStatusInfo = (status: string) => {
   switch (status) {
-    case 'draft': return { label: "Draft", color: "bg-gray-600", icon: Edit };
-    case 'with_second_appraiser': return { label: "With 2nd Appraiser", color: "bg-blue-600", icon: Mail };
-    case 'awaiting_employee': return { label: "Awaiting Employee", color: "bg-yellow-600", icon: Info };
-    case 'complete': return { label: "Complete", color: "bg-green-600", icon: CheckCircle };
-    default: return { label: "Unknown", color: "bg-gray-600", icon: Info };
+    case "draft":
+      return { label: "Draft", color: "bg-gray-600", icon: Edit };
+    case "with_second_appraiser":
+      return { label: "With 2nd Appraiser", color: "bg-blue-600", icon: Mail };
+    case "awaiting_employee":
+      return { label: "Awaiting Employee", color: "bg-yellow-600", icon: Info };
+    case "complete":
+      return { label: "Complete", color: "bg-green-600", icon: CheckCircle };
+    default:
+      return { label: "Unknown", color: "bg-gray-600", icon: Info };
   }
 };
 
@@ -92,16 +134,17 @@ export default function ReviewAndSignOffStep({
   employee,
   overallRating,
   onSubmit,
-  isLoading
+  isLoading,
 }: ReviewAndSignOffStepProps) {
   const [showSignatureModal, setShowSignatureModal] = useState(false);
-  
+  const { getRolePageUrl } = useRoleBasedNavigation();
+
   const category = getRatingCategory(overallRating);
   const statusInfo = getStatusInfo(appraisalData.status);
   const StatusIcon = statusInfo.icon;
-  
-  const ratedGoals = appraisalData.goals.filter(goal => goal.rating !== undefined);
-  const ratedCompetencies = appraisalData.competencies.filter(comp => comp.rating !== undefined);
+
+  const ratedGoals = appraisalData.goals.filter((goal) => goal.rating !== undefined);
+  const ratedCompetencies = appraisalData.competencies.filter((comp) => comp.rating !== undefined);
   const totalItems = ratedGoals.length + ratedCompetencies.length;
 
   if (totalItems === 0) {
@@ -113,13 +156,13 @@ export default function ReviewAndSignOffStep({
             <Breadcrumb>
               <BreadcrumbList>
                 <BreadcrumbItem>
-                  <BreadcrumbLink href="/dashboard">
+                  <BreadcrumbLink href={getRolePageUrl("dashboard")}>
                     <Home className="h-4 w-4" />
                   </BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
-                  <BreadcrumbLink href="/appraisals">Appraisals</BreadcrumbLink>
+                  <BreadcrumbLink href={getRolePageUrl("appraisals")}>Appraisals</BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
@@ -149,13 +192,13 @@ export default function ReviewAndSignOffStep({
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem>
-                <BreadcrumbLink href="/dashboard">
+                <BreadcrumbLink href={getRolePageUrl("dashboard")}>
                   <Home className="h-4 w-4" />
                 </BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator />
               <BreadcrumbItem>
-                <BreadcrumbLink href="/appraisals">Appraisals</BreadcrumbLink>
+                <BreadcrumbLink href={getRolePageUrl("appraisals")}>Appraisals</BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator />
               <BreadcrumbItem>
@@ -174,9 +217,16 @@ export default function ReviewAndSignOffStep({
                 Review the complete appraisal summary and submit for approval.
               </p>
             </div>
-            
+
             <div className="flex items-center gap-3">
-              <Badge variant="secondary" className={cn("flex items-center gap-2", statusInfo.color, "text-white focus:outline focus:ring-2 focus:ring-offset-2 focus:ring-primary")}>
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "flex items-center gap-2",
+                  statusInfo.color,
+                  "text-white focus:outline focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+                )}
+              >
                 <StatusIcon className="h-3 w-3" />
                 {statusInfo.label}
               </Badge>
@@ -187,7 +237,8 @@ export default function ReviewAndSignOffStep({
             <Alert className="mt-4">
               <Info className="h-4 w-4" />
               <AlertDescription>
-                Reviewing appraisal for <strong>{employee.name}</strong> ({employee.position}, {employee.department})
+                Reviewing appraisal for <strong>{employee.name}</strong> ({employee.position},{" "}
+                {employee.department})
               </AlertDescription>
             </Alert>
           )}
@@ -199,12 +250,15 @@ export default function ReviewAndSignOffStep({
             <CardHeader>
               <CardTitle className="flex items-center justify-between">
                 <span>Overall Performance Rating</span>
-                <motion.div 
+                <motion.div
                   initial={{ scale: 0.9, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
                   transition={{ delay: 0.2 }}
                 >
-                  <Badge variant="secondary" className={cn("text-lg px-4 py-2", category.color, "text-white")}>
+                  <Badge
+                    variant="secondary"
+                    className={cn("text-lg px-4 py-2", category.color, "text-white")}
+                  >
                     {overallRating.toFixed(1)}/5.0
                   </Badge>
                 </motion.div>
@@ -217,19 +271,19 @@ export default function ReviewAndSignOffStep({
                     {category.label}
                   </h3>
                   <p className="text-sm text-muted-foreground mt-1">
-                    Based on {totalItems} rated item{totalItems !== 1 ? 's' : ''}
+                    Based on {totalItems} rated item{totalItems !== 1 ? "s" : ""}
                   </p>
                 </div>
                 <div className="flex items-center gap-1">
-                  {[1, 2, 3, 4, 5].map(star => (
-                    <Star 
-                      key={star} 
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <Star
+                      key={star}
                       className={cn(
                         "h-6 w-6",
-                        star <= Math.round(overallRating) 
-                          ? "fill-yellow-400 text-yellow-400" 
+                        star <= Math.round(overallRating)
+                          ? "fill-yellow-400 text-yellow-400"
                           : "text-gray-300"
-                      )} 
+                      )}
                     />
                   ))}
                 </div>
@@ -305,7 +359,10 @@ export default function ReviewAndSignOffStep({
                     </TableHeader>
                     <TableBody>
                       {ratedCompetencies.map((competency, index) => (
-                        <TableRow key={competency.id} className={index % 2 === 0 ? "bg-muted/50" : ""}>
+                        <TableRow
+                          key={competency.id}
+                          className={index % 2 === 0 ? "bg-muted/50" : ""}
+                        >
                           <TableCell>
                             <div>
                               <h4 className="font-medium text-sm">{competency.title}</h4>
@@ -345,7 +402,9 @@ export default function ReviewAndSignOffStep({
                   {appraisalData.signatures.appraiser ? (
                     <div className="flex items-center gap-2 p-3 bg-green-50 border border-green-200 rounded-lg">
                       <CheckCircle className="h-4 w-4 text-green-600" />
-                      <span className="text-sm font-medium">{appraisalData.signatures.appraiser}</span>
+                      <span className="text-sm font-medium">
+                        {appraisalData.signatures.appraiser}
+                      </span>
                     </div>
                   ) : (
                     <div className="p-3 bg-muted/50 border border-dashed rounded-lg text-center">
@@ -420,9 +479,9 @@ export default function ReviewAndSignOffStep({
                   </p>
                 </div>
                 <div className="flex gap-3">
-                  <Button 
+                  <Button
                     size="lg"
-                    className="flex items-center gap-2" 
+                    className="flex items-center gap-2"
                     disabled={isLoading || !!appraisalData.signatures.appraiser}
                     onClick={() => setShowSignatureModal(true)}
                   >


### PR DESCRIPTION
## Summary
- add role-based navigation hook to `ReviewAndSignOffStep`
- use `getRolePageUrl` when rendering dashboard and appraisal links

## Testing
- `npm run lint` *(fails: 2727 problems)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688be7173c30832c8e703b021aee837c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and consistency for better readability.
  * Updated string literals and whitespace for uniform style.

* **New Features**
  * Breadcrumb navigation links now adapt dynamically based on user role, providing role-based URLs for "dashboard" and "appraisals".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->