### PR TITLE
Validate role in dashboard route

### DIFF
--- a/src/components/DashboardRoute.tsx
+++ b/src/components/DashboardRoute.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import Dashboard from "./Dashboard";
+import { usePermissions, type AppRole } from "@/hooks/usePermissions";
+import { RouteLoader } from "./ui/navigation-loader";
+import { getRolePrefix } from "@/lib/utils";
+
+const allowedRoles: AppRole[] = [
+  "admin",
+  "director",
+  "manager",
+  "supervisor",
+  "employee"
+];
+
+export default function DashboardRoute() {
+  const { role } = useParams<{ role?: AppRole }>();
+  const navigate = useNavigate();
+  const permissions = usePermissions();
+
+  const userRolePrefix = () => {
+    if (permissions.isAdmin) return getRolePrefix("admin");
+    if (permissions.isDirector) return getRolePrefix("director");
+    if (permissions.isManager) return getRolePrefix("manager");
+    if (permissions.isSupervisor) return getRolePrefix("supervisor");
+    return getRolePrefix("employee");
+  };
+
+  const roleValid = role && allowedRoles.includes(role);
+  const userHasRole = roleValid ? permissions.hasRole(role as AppRole) : false;
+
+  useEffect(() => {
+    if (permissions.loading) return;
+
+    if (!roleValid) {
+      navigate("/unauthorized", { replace: true });
+      return;
+    }
+
+    if (!userHasRole) {
+      navigate(`/${userRolePrefix()}/dashboard`, { replace: true });
+    }
+  }, [permissions.loading, roleValid, userHasRole, navigate]);
+
+  if (permissions.loading) {
+    return <RouteLoader />;
+  }
+
+  if (!roleValid || !userHasRole) {
+    return null;
+  }
+
+  return <Dashboard />;
+}

--- a/src/config/components.ts
+++ b/src/config/components.ts
@@ -3,6 +3,7 @@ import { lazy } from 'react';
 
 // Dashboard
 export const Dashboard = lazy(() => import('@/components/Dashboard'));
+export const DashboardRoute = lazy(() => import('@/components/DashboardRoute'));
 
 // Admin components
 export const LazyEmployeesPage = lazy(() => import('@/pages/admin/employees/EmployeesPage'));
@@ -45,6 +46,7 @@ export const LazyManagerTeamSection = lazy(() => import('@/components/manager/Ma
 // Component registry for easy lookup
 export const componentRegistry = {
   Dashboard,
+  DashboardRoute,
   LazyEmployeesPage,
   LazyEmployeeImportPage,
   LazyAppraisalCyclesPage,

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -16,7 +16,7 @@ export const routeConfig: RouteConfig[] = [
   // Dashboard routes (all roles)
   {
     path: '/:role/dashboard',
-    component: 'Dashboard',
+    component: 'DashboardRoute',
     roles: ['admin', 'director', 'manager', 'supervisor', 'employee'],
     title: 'Dashboard',
     description: 'Main dashboard view'


### PR DESCRIPTION
## Summary
- add `DashboardRoute` component that verifies `useParams().role`
- register the new component in `componentRegistry`
- use it in `routeConfig` for `/:role/dashboard`

## Testing
- `npm run lint` *(fails: Resolve error - typescript with invalid interface loaded as resolver)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688be716cfd0832c9fb56d68bfc5daba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced role-based access control for the dashboard page, ensuring users are redirected appropriately based on their permissions and role in the URL.
  * Added loading indicators while permissions are being verified.

* **Refactor**
  * Updated the dashboard route to use the new role-aware component for improved access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->