### PR TITLE
Fix new item links to use role-aware URLs

### DIFF
--- a/src/components/AppraisalsPage.tsx
+++ b/src/components/AppraisalsPage.tsx
@@ -1,23 +1,21 @@
-
 import AppraisalsContent from "./Appraisals";
 import { PageHeader } from "@/components/ui/page-header";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { usePermissions } from "@/hooks/usePermissions";
+import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 
 const AppraisalsPage = () => {
   const navigate = useNavigate();
   const permissions = usePermissions();
+  const { getRolePageUrl } = useRoleBasedNavigation();
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <PageHeader
-        title="Appraisals"
-        description="Manage and track employee performance appraisals"
-      >
+      <PageHeader title="Appraisals" description="Manage and track employee performance appraisals">
         {permissions.canCreateAppraisals && (
-          <Button onClick={() => navigate("/appraisals/new")}>
+          <Button onClick={() => navigate(getRolePageUrl("appraisals/new"))}>
             <Plus className="mr-2 h-4 w-4" />
             New Appraisal
           </Button>

--- a/src/components/GoalsPage.tsx
+++ b/src/components/GoalsPage.tsx
@@ -1,14 +1,18 @@
-
 import { lazy, Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { usePermissions } from "@/hooks/usePermissions";
+import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 import { PageHeader } from "@/components/ui/page-header";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const LazyManagerGoalsDashboard = lazy(() => import("./LazyManagerGoalsDashboard"));
-const DirectorGoalsDashboard = lazy(() => import("./goals/DirectorGoalsDashboard").then(module => ({ default: module.DirectorGoalsDashboard })));
+const DirectorGoalsDashboard = lazy(() =>
+  import("./goals/DirectorGoalsDashboard").then((module) => ({
+    default: module.DirectorGoalsDashboard,
+  }))
+);
 
 const GoalsDashboardSkeleton = () => (
   <div className="space-y-6">
@@ -23,27 +27,21 @@ const GoalsDashboardSkeleton = () => (
 const GoalsPage = () => {
   const navigate = useNavigate();
   const permissions = usePermissions();
+  const { getRolePageUrl } = useRoleBasedNavigation();
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <PageHeader
-        title="Goals"
-        description="Track and manage performance goals"
-      >
+      <PageHeader title="Goals" description="Track and manage performance goals">
         {permissions.canManageGoals && (
-          <Button onClick={() => navigate("/goals/new")}>
+          <Button onClick={() => navigate(getRolePageUrl("goals/new"))}>
             <Plus className="mr-2 h-4 w-4" />
             Create Goal
           </Button>
         )}
       </PageHeader>
-      
+
       <Suspense fallback={<GoalsDashboardSkeleton />}>
-        {permissions.isDirector ? (
-          <DirectorGoalsDashboard />
-        ) : (
-          <LazyManagerGoalsDashboard />
-        )}
+        {permissions.isDirector ? <DirectorGoalsDashboard /> : <LazyManagerGoalsDashboard />}
       </Suspense>
     </div>
   );

--- a/src/components/appraisals/ManagerAppraisalsDashboard.tsx
+++ b/src/components/appraisals/ManagerAppraisalsDashboard.tsx
@@ -2,10 +2,18 @@ import { useState, useEffect, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Search, Plus, User, AlertCircle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTable } from "@/components/ui/data-table";
@@ -40,33 +48,37 @@ function getRoleBasedEmptyState(roles: string[], isSearching: boolean, searchTer
     return {
       title: "No appraisals found",
       description: `No appraisals match "${searchTerm}". Try adjusting your search or filters.`,
-      showCreateButton: false
+      showCreateButton: false,
     };
   }
 
-  if (roles.includes('employee') && !roles.some(r => ['admin', 'director', 'manager', 'supervisor'].includes(r))) {
+  if (
+    roles.includes("employee") &&
+    !roles.some((r) => ["admin", "director", "manager", "supervisor"].includes(r))
+  ) {
     return {
       title: "No appraisals yet",
-      description: "You don't have any appraisals for this period. Check with your manager for upcoming performance reviews.",
-      showCreateButton: false
+      description:
+        "You don't have any appraisals for this period. Check with your manager for upcoming performance reviews.",
+      showCreateButton: false,
     };
-  } else if (roles.includes('manager') || roles.includes('supervisor')) {
+  } else if (roles.includes("manager") || roles.includes("supervisor")) {
     return {
       title: "No team appraisals yet",
       description: "Get started by creating appraisals for your team members.",
-      showCreateButton: true
+      showCreateButton: true,
     };
-  } else if (roles.includes('director')) {
+  } else if (roles.includes("director")) {
     return {
       title: "No division appraisals yet",
       description: "Start conducting appraisals for your division to track performance.",
-      showCreateButton: true
+      showCreateButton: true,
     };
   } else {
     return {
       title: "No appraisals in the system",
       description: "Get started by creating the first appraisals for your organization.",
-      showCreateButton: true
+      showCreateButton: true,
     };
   }
 }
@@ -121,25 +133,20 @@ function LoadingSkeleton() {
 function AppraisalsEmptyState({
   isSearching,
   searchTerm,
-  roles
+  roles,
 }: {
   isSearching: boolean;
   searchTerm: string;
   roles: string[];
 }) {
+  const navigate = useNavigate();
+  const { getRolePageUrl } = useRoleBasedNavigation();
   const emptyState = getRoleBasedEmptyState(roles, isSearching, searchTerm);
-  
+
   return (
-    <EmptyState
-      icon={Search}
-      title={emptyState.title}
-      description={emptyState.description}
-    >
+    <EmptyState icon={Search} title={emptyState.title} description={emptyState.description}>
       {emptyState.showCreateButton && (
-        <Button 
-          className="gap-2" 
-          onClick={() => window.location.href = "/appraisals/new"}
-        >
+        <Button className="gap-2" onClick={() => navigate(getRolePageUrl("appraisals/new"))}>
           <Plus className="w-4 h-4" />
           Create Appraisal
         </Button>
@@ -159,12 +166,17 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
   const [selectedAppraisal, setSelectedAppraisal] = useState<Appraisal | null>(null);
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const { isMobile } = useMobileResponsive();
-  
+
   // Hooks
   const { roles, canCreateAppraisals } = usePermissions();
-  const { data: appraisals, isLoading: loading, error, refetch } = useAppraisals({
+  const {
+    data: appraisals,
+    isLoading: loading,
+    error,
+    refetch,
+  } = useAppraisals({
     year: yearFilter,
-    status: statusFilter === "All" ? undefined : statusFilter
+    status: statusFilter === "All" ? undefined : statusFilter,
   });
 
   // Debounced search
@@ -178,8 +190,8 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
 
   // Filter appraisals
   const filteredAppraisals = useMemo(() => {
-    return appraisals.filter(appraisal => {
-      const matchesSearch = 
+    return appraisals.filter((appraisal) => {
+      const matchesSearch =
         appraisal.employeeName.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ||
         appraisal.department.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ||
         appraisal.appraiser.toLowerCase().includes(debouncedSearchTerm.toLowerCase());
@@ -196,11 +208,7 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
   if (error) {
     return (
       <div className={cn("space-y-6", className)}>
-        <EmptyState
-          icon={AlertCircle}
-          title="Error loading appraisals"
-          description={error}
-        >
+        <EmptyState icon={AlertCircle} title="Error loading appraisals" description={error}>
           <Button onClick={() => refetch()} variant="outline" className="gap-2">
             <RefreshCw className="w-4 h-4" />
             Try Again
@@ -213,18 +221,20 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
   return (
     <div className={cn("space-y-6", className)}>
       {/* Search and Filters */}
-      <div className={`flex gap-4 items-start ${isMobile ? 'flex-col' : 'flex-col sm:flex-row sm:items-center'}`}>
+      <div
+        className={`flex gap-4 items-start ${isMobile ? "flex-col" : "flex-col sm:flex-row sm:items-center"}`}
+      >
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
             placeholder="Search appraisals or employees..."
             value={searchTerm}
-            onChange={e => setSearchTerm(e.target.value)}
+            onChange={(e) => setSearchTerm(e.target.value)}
             className="pl-10"
           />
         </div>
-        
-        <div className={`flex gap-4 ${isMobile ? 'flex-col w-full' : 'flex-row'}`}>
+
+        <div className={`flex gap-4 ${isMobile ? "flex-col w-full" : "flex-row"}`}>
           <Select value={statusFilter} onValueChange={setStatusFilter}>
             <SelectTrigger className={isMobile ? "w-full" : "w-40"}>
               <SelectValue placeholder="Status" />
@@ -265,7 +275,9 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
             exit={{ opacity: 0, y: -20 }}
           >
             <AppraisalsEmptyState
-              isSearching={debouncedSearchTerm.length > 0 || statusFilter !== "All" || yearFilter !== "All"}
+              isSearching={
+                debouncedSearchTerm.length > 0 || statusFilter !== "All" || yearFilter !== "All"
+              }
               searchTerm={debouncedSearchTerm}
               roles={roles}
             />
@@ -282,42 +294,36 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
               <MobileTable
                 data={filteredAppraisals}
                 renderCard={(appraisal) => (
-                  <Card key={appraisal.id} className="p-4 space-y-3 cursor-pointer hover:bg-accent/50 transition-colors">
+                  <Card
+                    key={appraisal.id}
+                    className="p-4 space-y-3 cursor-pointer hover:bg-accent/50 transition-colors"
+                  >
                     <div className="flex items-center justify-between">
                       <div className="font-medium text-sm">{appraisal.employeeName}</div>
                       <Badge className={cn("text-xs", getStatusColor(appraisal.status))}>
-                        {appraisal.status.replace('_', ' ')}
+                        {appraisal.status.replace("_", " ")}
                       </Badge>
                     </div>
-                    
-                    <MobileTableRow 
-                      label="Department" 
-                      value={appraisal.department}
+
+                    <MobileTableRow label="Department" value={appraisal.department} />
+
+                    <MobileTableRow label="Type" value={appraisal.type} />
+
+                    <MobileTableRow
+                      label="Score"
+                      value={appraisal.score ? appraisal.score.toString() : "Not Rated"}
                     />
-                    
-                    <MobileTableRow 
-                      label="Type" 
-                      value={appraisal.type} 
-                    />
-                    
-                    <MobileTableRow 
-                      label="Score" 
-                      value={appraisal.score ? appraisal.score.toString() : 'Not Rated'} 
-                    />
-                    
-                    <MobileTableRow 
-                      label="Performance" 
-                      value={appraisal.performance} 
-                    />
-                    
-                    <MobileTableRow 
-                      label="Appraiser" 
+
+                    <MobileTableRow label="Performance" value={appraisal.performance} />
+
+                    <MobileTableRow
+                      label="Appraiser"
                       value={
                         <div className="flex items-center gap-2">
                           <User className="w-4 h-4 text-muted-foreground" />
                           <span>{appraisal.appraiser}</span>
                         </div>
-                      } 
+                      }
                     />
                   </Card>
                 )}
@@ -336,17 +342,19 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
 
       {/* Appraisal Detail Modal */}
       <Dialog open={isDetailModalOpen} onOpenChange={setIsDetailModalOpen}>
-        <DialogContent className={isMobile ? "max-w-[95vw] max-h-[90vh] overflow-y-auto" : "max-w-2xl"}>
+        <DialogContent
+          className={isMobile ? "max-w-[95vw] max-h-[90vh] overflow-y-auto" : "max-w-2xl"}
+        >
           <DialogHeader>
-            <DialogTitle className={`font-semibold ${isMobile ? 'text-lg' : 'text-xl'}`}>
+            <DialogTitle className={`font-semibold ${isMobile ? "text-lg" : "text-xl"}`}>
               {selectedAppraisal?.employeeName} - Performance Appraisal
             </DialogTitle>
           </DialogHeader>
           {selectedAppraisal && (
             <div className="space-y-6">
-              <div className={`flex gap-4 ${isMobile ? 'flex-col' : 'items-center'}`}>
+              <div className={`flex gap-4 ${isMobile ? "flex-col" : "items-center"}`}>
                 <Badge className={cn("text-sm w-fit", getStatusColor(selectedAppraisal.status))}>
-                  {selectedAppraisal.status.replace('_', ' ')}
+                  {selectedAppraisal.status.replace("_", " ")}
                 </Badge>
                 <div className="flex items-center gap-2 text-muted-foreground">
                   <User className="w-4 h-4" />
@@ -354,7 +362,7 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
                 </div>
               </div>
 
-              <div className={`grid gap-4 text-sm ${isMobile ? 'grid-cols-1' : 'grid-cols-2'}`}>
+              <div className={`grid gap-4 text-sm ${isMobile ? "grid-cols-1" : "grid-cols-2"}`}>
                 <div>
                   <span className="font-medium">Department:</span> {selectedAppraisal.department}
                 </div>
@@ -365,7 +373,8 @@ export function ManagerAppraisalsDashboard({ className }: ManagerAppraisalsDashb
                   <span className="font-medium">Type:</span> {selectedAppraisal.type}
                 </div>
                 <div>
-                  <span className="font-medium">Score:</span> {selectedAppraisal.score || 'Not Rated'}
+                  <span className="font-medium">Score:</span>{" "}
+                  {selectedAppraisal.score || "Not Rated"}
                 </div>
                 <div>
                   <span className="font-medium">Performance:</span> {selectedAppraisal.performance}

--- a/src/components/goals/DirectorGoalsDashboard.tsx
+++ b/src/components/goals/DirectorGoalsDashboard.tsx
@@ -3,10 +3,17 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Search, Plus, User, AlertCircle, RefreshCw } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableAdvancedToolbar } from "@/components/ui/data-table-advanced-toolbar";
 import { DataTableFilterList } from "@/components/ui/data-table-filter-list";
@@ -32,21 +39,20 @@ function DivisionGoalCard() {
             <div className="space-y-2 flex-1">
               <h3 className="text-lg font-semibold text-foreground">2025 Division Goal</h3>
               <p className="text-muted-foreground leading-relaxed">
-                Increase customer satisfaction scores by 25% through improved service delivery and enhanced product quality initiatives across all departments.
+                Increase customer satisfaction scores by 25% through improved service delivery and
+                enhanced product quality initiatives across all departments.
               </p>
             </div>
           </div>
-          
+
           <div className="flex items-center gap-2 text-sm">
             <User className="w-4 h-4 text-muted-foreground" />
             <span className="text-foreground font-medium">Sarah Johnson</span>
             <span className="text-muted-foreground">•</span>
             <span className="text-muted-foreground">Division Director</span>
           </div>
-          
-          <div className="text-xs text-muted-foreground">
-            see full goal
-          </div>
+
+          <div className="text-xs text-muted-foreground">see full goal</div>
         </div>
       </CardContent>
     </Card>
@@ -98,22 +104,24 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
   const [yearFilter, setYearFilter] = useState<string>("All");
   const { isMobile } = useMobileResponsive();
   const navigate = useNavigate();
-  
+  const { getRolePageUrl } = useRoleBasedNavigation();
+
   // Hooks
   const { roles, canManageGoals } = usePermissions();
   const { departments } = useDepartments();
   const { goals, loading, error, refetch } = useGoals({
-    year: yearFilter === "All" ? undefined : yearFilter
+    year: yearFilter === "All" ? undefined : yearFilter,
   });
 
   // Filter goals by department and year (advanced filtering will handle search)
   const filteredGoals = useMemo(() => {
-    return goals.filter(goal => {
+    return goals.filter((goal) => {
       // For department filter, we would need to add department info to the goal data
       // For now, we'll just filter by department name in the search
-      const matchesDepartment = departmentFilter === "All" || 
+      const matchesDepartment =
+        departmentFilter === "All" ||
         goal.employeeName.toLowerCase().includes(departmentFilter.toLowerCase());
-      
+
       return matchesDepartment;
     });
   }, [goals, departmentFilter]);
@@ -126,11 +134,7 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
   if (error) {
     return (
       <div className={cn("space-y-6", className)}>
-        <EmptyState
-          icon={AlertCircle}
-          title="Error loading goals"
-          description={error}
-        >
+        <EmptyState icon={AlertCircle} title="Error loading goals" description={error}>
           <Button onClick={() => refetch()} variant="outline" className="gap-2">
             <RefreshCw className="w-4 h-4" />
             Try Again
@@ -153,7 +157,7 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
             <p className="text-sm text-muted-foreground">Track and manage your team's progress</p>
           </div>
           {canManageGoals && (
-            <Button onClick={() => navigate("/goals/new")} className="gap-2">
+            <Button onClick={() => navigate(getRolePageUrl("goals/new"))} className="gap-2">
               <Plus className="w-4 h-4" />
               Create Goal
             </Button>
@@ -161,7 +165,7 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
         </div>
 
         {/* Department and Year Filters */}
-        <div className={`flex gap-4 ${isMobile ? 'flex-col w-full' : 'flex-row'}`}>
+        <div className={`flex gap-4 ${isMobile ? "flex-col w-full" : "flex-row"}`}>
           <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
             <SelectTrigger className={isMobile ? "w-full" : "w-40"}>
               <SelectValue placeholder="Department" />
@@ -214,7 +218,7 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
                 }
               >
                 {canManageGoals && (
-                  <Button onClick={() => navigate("/goals/new")} className="gap-2">
+                  <Button onClick={() => navigate(getRolePageUrl("goals/new"))} className="gap-2">
                     <Plus className="w-4 h-4" />
                     Create Goal
                   </Button>
@@ -233,38 +237,35 @@ export function DirectorGoalsDashboard({ className }: DirectorGoalsDashboardProp
                 <MobileTable
                   data={filteredGoals}
                   renderCard={(goal) => (
-                    <Card key={goal.id} className="p-4 space-y-3 cursor-pointer hover:bg-accent/50 transition-colors">
+                    <Card
+                      key={goal.id}
+                      className="p-4 space-y-3 cursor-pointer hover:bg-accent/50 transition-colors"
+                    >
                       <div className="flex items-center justify-between">
                         <div className="font-medium text-sm">{goal.title}</div>
                         <Badge variant="secondary" className="text-xs">
                           {goal.status}
                         </Badge>
                       </div>
-                      
-                      <MobileTableRow 
-                        label="Employee" 
+
+                      <MobileTableRow
+                        label="Employee"
                         value={
                           <div className="flex items-center gap-2">
                             <User className="w-4 h-4 text-muted-foreground" />
                             <span>{goal.employeeName}</span>
                           </div>
-                        } 
+                        }
                       />
-                      
-                      <MobileTableRow 
-                        label="Job Title" 
-                        value="Position" 
-                      />
+
+                      <MobileTableRow label="Job Title" value="Position" />
                     </Card>
                   )}
                   onItemClick={handleGoalClick}
                   emptyMessage="No goals found"
                 />
               ) : (
-                <DirectorGoalsTable
-                  goals={filteredGoals}
-                  onGoalClick={handleGoalClick}
-                />
+                <DirectorGoalsTable goals={filteredGoals} onGoalClick={handleGoalClick} />
               )}
             </motion.div>
           )}


### PR DESCRIPTION
## Summary
- calculate role-aware URLs when navigating to create goal/appraisal pages
- use role-based navigation in dashboards and pages

## Testing
- `npm run lint` *(fails: cannot resolve ESLint deps)*
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688be714cc50832c94f1353292509c2f