### PR TITLE
Implement goal creation via Supabase

### DIFF
--- a/src/components/MagicPathGoalCreator.tsx
+++ b/src/components/MagicPathGoalCreator.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
-import { toast } from 'sonner';
-import { GoalProgressIndicator } from './goals/creation/GoalProgressIndicator';
-import { GoalBasicsStep } from './goals/creation/GoalBasicsStep';
-import { GoalAssignmentStep } from './goals/creation/GoalAssignmentStep';
-import { GoalSchedulingStep } from './goals/creation/GoalSchedulingStep';
-import { GoalNavigationButtons } from './goals/creation/GoalNavigationButtons';
-import { GoalData, GoalCreationStep } from './goals/creation/types';
+import React, { useState } from "react";
+import { toast } from "sonner";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import { GoalProgressIndicator } from "./goals/creation/GoalProgressIndicator";
+import { GoalBasicsStep } from "./goals/creation/GoalBasicsStep";
+import { GoalAssignmentStep } from "./goals/creation/GoalAssignmentStep";
+import { GoalSchedulingStep } from "./goals/creation/GoalSchedulingStep";
+import { GoalNavigationButtons } from "./goals/creation/GoalNavigationButtons";
+import { GoalData, GoalCreationStep } from "./goals/creation/types";
 
 interface MagicPathGoalCreatorProps {
   onComplete?: (goalData: GoalData) => void;
@@ -13,13 +15,13 @@ interface MagicPathGoalCreatorProps {
 
 export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps): JSX.Element {
   const [goalData, setGoalData] = useState<GoalData>({
-    title: '',
-    description: '',
-    assignee: '',
+    title: "",
+    description: "",
+    assignee: "",
     selectedEmployee: null,
     selectedEmployees: [],
     dueDate: undefined,
-    priority: 'Medium'
+    priority: "Medium",
   });
 
   const [currentStep, setCurrentStep] = useState(0);
@@ -28,18 +30,18 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
     {
       title: "Select Employees",
       subtitle: "Choose team members who will work on this goal",
-      fields: ['assignee']
+      fields: ["assignee"],
     },
     {
       title: "Goal Details",
       subtitle: "Define the goal title and description",
-      fields: ['title', 'description']
+      fields: ["title", "description"],
     },
     {
       title: "Schedule & Priority",
       subtitle: "Set optional due date and priority level",
-      fields: ['dueDate', 'priority']
-    }
+      fields: ["dueDate", "priority"],
+    },
   ];
 
   const handleNext = () => {
@@ -54,25 +56,93 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
     setCurrentStep(Math.max(0, currentStep - 1));
   };
 
-  const handleComplete = () => {
-    toast.success("Goal created successfully!");
-    onComplete?.(goalData);
+  const navigate = useNavigate();
+
+  const handleComplete = async () => {
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        toast.error("User not authenticated");
+        return;
+      }
+
+      const { data: employeeInfo, error: employeeError } = await supabase
+        .from("employee_info")
+        .select("id, organization_id")
+        .eq("user_id", user.id)
+        .single();
+
+      if (employeeError || !employeeInfo) {
+        toast.error("Failed to load profile information");
+        return;
+      }
+
+      const startDate = new Date().toISOString().split("T")[0];
+      const dueDate = goalData.dueDate ? goalData.dueDate.toISOString().split("T")[0] : startDate;
+
+      const { data: goal, error: goalError } = await supabase
+        .from("goals")
+        .insert({
+          created_by: employeeInfo.id,
+          organization_id: employeeInfo.organization_id,
+          title: goalData.title,
+          description: goalData.description || null,
+          start_date: startDate,
+          due_date: dueDate,
+          priority: goalData.priority,
+          status: "active",
+          progress: 0,
+        })
+        .select()
+        .single();
+
+      if (goalError || !goal) {
+        throw goalError || new Error("Goal insertion failed");
+      }
+
+      if (goalData.selectedEmployees.length > 0) {
+        const assignments = goalData.selectedEmployees.map((emp) => ({
+          goal_id: goal.id,
+          employee_id: emp.id,
+          assigned_by: employeeInfo.id,
+          assigned_at: new Date().toISOString(),
+        }));
+
+        const { error: assignmentError } = await supabase
+          .from("goal_assignments")
+          .insert(assignments);
+
+        if (assignmentError) {
+          throw assignmentError;
+        }
+      }
+
+      toast.success("Goal created successfully!");
+      onComplete?.(goalData);
+      navigate("/manager/team/goals");
+    } catch (error) {
+      console.error("Error creating goal:", error);
+      toast.error("Failed to create goal");
+    }
   };
 
   const isStepComplete = (stepIndex: number) => {
     const step = steps[stepIndex];
-    return step.fields.every(field => {
+    return step.fields.every((field) => {
       // Step 2 (Additional details) - due date and priority are optional
-      if (stepIndex === 2 && (field === 'dueDate' || field === 'priority')) return true;
-      if (field === 'assignee') return goalData.selectedEmployees.length > 0;
-      return goalData[field] !== '';
+      if (stepIndex === 2 && (field === "dueDate" || field === "priority")) return true;
+      if (field === "assignee") return goalData.selectedEmployees.length > 0;
+      return goalData[field] !== "";
     });
   };
 
   const canProceed = isStepComplete(currentStep);
 
   const updateGoalData = <K extends keyof GoalData>(field: K, value: GoalData[K]) => {
-    setGoalData(prev => ({ ...prev, [field]: value }));
+    setGoalData((prev) => ({ ...prev, [field]: value }));
   };
 
   const renderStepContent = () => {
@@ -83,9 +153,9 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
             assignee={goalData.assignee}
             selectedEmployee={goalData.selectedEmployee}
             selectedEmployees={goalData.selectedEmployees}
-            onAssigneeChange={(value) => updateGoalData('assignee', value)}
-            onEmployeeSelect={(employee) => updateGoalData('selectedEmployee', employee)}
-            onEmployeesSelect={(employees) => updateGoalData('selectedEmployees', employees)}
+            onAssigneeChange={(value) => updateGoalData("assignee", value)}
+            onEmployeeSelect={(employee) => updateGoalData("selectedEmployee", employee)}
+            onEmployeesSelect={(employees) => updateGoalData("selectedEmployees", employees)}
           />
         );
       case 1:
@@ -93,8 +163,8 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
           <GoalBasicsStep
             title={goalData.title}
             description={goalData.description}
-            onTitleChange={(value) => updateGoalData('title', value)}
-            onDescriptionChange={(value) => updateGoalData('description', value)}
+            onTitleChange={(value) => updateGoalData("title", value)}
+            onDescriptionChange={(value) => updateGoalData("description", value)}
           />
         );
       case 2:
@@ -102,8 +172,8 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
           <GoalSchedulingStep
             dueDate={goalData.dueDate}
             priority={goalData.priority}
-            onDueDateChange={(value) => updateGoalData('dueDate', value)}
-            onPriorityChange={(value) => updateGoalData('priority', value)}
+            onDueDateChange={(value) => updateGoalData("dueDate", value)}
+            onPriorityChange={(value) => updateGoalData("priority", value)}
           />
         );
       default:
@@ -113,15 +183,10 @@ export function MagicPathGoalCreator({ onComplete }: MagicPathGoalCreatorProps):
 
   return (
     <div className="space-y-8">
-      <GoalProgressIndicator 
-        currentStep={currentStep} 
-        totalSteps={steps.length} 
-      />
-      
-      <div className="max-w-3xl mx-auto">
-        {renderStepContent()}
-      </div>
-      
+      <GoalProgressIndicator currentStep={currentStep} totalSteps={steps.length} />
+
+      <div className="max-w-3xl mx-auto">{renderStepContent()}</div>
+
       <div className="max-w-3xl mx-auto">
         <GoalNavigationButtons
           currentStep={currentStep}


### PR DESCRIPTION
## Summary
- create goals in `MagicPathGoalCreator` via Supabase
- insert goal assignments for selected employees
- navigate to goals page when done

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run type-check` *(fails: missing script)*
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_688c0435198c832ca86cc0db9d9c8089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal creation now saves data persistently and assigns goals to selected employees.
  * Users receive clear success or error messages during the goal creation process.
  * After creating a goal, users are automatically redirected to the team goals page.

* **Bug Fixes**
  * Improved error handling with informative notifications for any issues during goal creation.

* **Style**
  * Minor updates for consistent formatting and quote usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->