### PR TITLE
feat: link audit logs to organizations

### DIFF
--- a/supabase/migrations/20250730025418-96997d6d-3464-4a3a-9049-19f5f105984d.sql
+++ b/supabase/migrations/20250730025418-96997d6d-3464-4a3a-9049-19f5f105984d.sql
@@ -4,7 +4,7 @@
 CREATE TABLE IF NOT EXISTS public.security_audit_log (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   user_id UUID REFERENCES auth.users(id),
-  organization_id UUID,
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
   event_type TEXT NOT NULL,
   event_details JSONB,
   ip_address INET,
@@ -15,6 +15,10 @@ CREATE TABLE IF NOT EXISTS public.security_audit_log (
 
 -- Enable RLS on audit log
 ALTER TABLE public.security_audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Index for efficient organization filtering
+CREATE INDEX idx_security_audit_log_organization_id
+  ON public.security_audit_log(organization_id);
 
 -- Only admins can view audit logs within their organization
 CREATE POLICY "Admins can view security audit logs in their organization" 
@@ -291,7 +295,7 @@ CREATE TABLE IF NOT EXISTS public.password_history (
 ALTER TABLE public.password_history ENABLE ROW LEVEL SECURITY;
 
 -- Only system can manage password history
-CREATE POLICY "System only access to password history" 
-ON public.password_history 
-FOR ALL 
+CREATE POLICY "System only access to password history"
+ON public.password_history
+FOR ALL
 USING (false);


### PR DESCRIPTION
## Summary
- link `security_audit_log.organization_id` to `public.organizations` with `ON DELETE SET NULL`
- index `security_audit_log.organization_id` for faster lookups

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689105dca264832ca825b256bfeabbbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved filtering performance in audit logs by adding an index for organization-based queries.
* **Chores**
  * Enhanced data integrity in audit logs by linking organization records and handling deletions more gracefully.
  * Minor formatting improvements for policy definitions (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->