### PR TITLE
test: add authentication and permission tests

### DIFF
--- a/src/components/OnboardingProtectedRoute.test.tsx
+++ b/src/components/OnboardingProtectedRoute.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import OnboardingProtectedRoute from './OnboardingProtectedRoute';
+import { vi } from 'vitest';
+
+const mockUseAuth = vi.fn();
+const mockUseOnboardingStatus = vi.fn();
+const mockDetermineOnboardingState = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('@/hooks/useOnboardingStatus', () => ({
+  useOnboardingStatus: () => mockUseOnboardingStatus(),
+}));
+
+vi.mock('@/lib/onboarding-utils', () => ({
+  determineOnboardingState: (...args: any[]) => mockDetermineOnboardingState(...args),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('./ui/navigation-loader', () => ({
+  RouteLoader: () => <div data-testid="loader" />,
+}));
+
+describe('OnboardingProtectedRoute', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('shows loader while determining status', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    mockUseOnboardingStatus.mockReturnValue({ onboardingCompleted: null, loading: true });
+    mockDetermineOnboardingState.mockReturnValue({ isLoading: true });
+    render(<OnboardingProtectedRoute>child</OnboardingProtectedRoute>);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('redirects to login when not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    mockUseOnboardingStatus.mockReturnValue({ onboardingCompleted: null, loading: false });
+    mockDetermineOnboardingState.mockReturnValue({
+      isLoading: false,
+      shouldRedirectToDashboard: false,
+      canAccessOnboarding: false,
+    });
+    render(<OnboardingProtectedRoute>child</OnboardingProtectedRoute>);
+    expect(mockNavigate).toHaveBeenCalledWith('/log-in');
+  });
+
+  it('redirects to dashboard when onboarding complete', () => {
+    mockUseAuth.mockReturnValue({ user: { id: '1' }, loading: false });
+    mockUseOnboardingStatus.mockReturnValue({ onboardingCompleted: true, loading: false });
+    mockDetermineOnboardingState.mockReturnValue({
+      isLoading: false,
+      shouldRedirectToDashboard: true,
+      canAccessOnboarding: false,
+    });
+    render(<OnboardingProtectedRoute>child</OnboardingProtectedRoute>);
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('renders children when access allowed', () => {
+    mockUseAuth.mockReturnValue({ user: { id: '1' }, loading: false });
+    mockUseOnboardingStatus.mockReturnValue({ onboardingCompleted: false, loading: false });
+    mockDetermineOnboardingState.mockReturnValue({
+      isLoading: false,
+      shouldRedirectToDashboard: false,
+      canAccessOnboarding: true,
+    });
+    render(
+      <OnboardingProtectedRoute>
+        <div data-testid="child" />
+      </OnboardingProtectedRoute>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});
+

--- a/src/hooks/useAuth.test.ts
+++ b/src/hooks/useAuth.test.ts
@@ -1,0 +1,80 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuth } from './useAuth';
+import { vi } from 'vitest';
+
+// Use hoisted mocks so they are available to the factory
+const { mockGetSession, mockSignInWithPassword, mockSignUp, mockSignOut } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockSignInWithPassword: vi.fn(),
+  mockSignUp: vi.fn(),
+  mockSignOut: vi.fn(),
+}));
+
+let authStateCallback: ((event: any, session: any) => void) | null = null;
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: mockGetSession,
+      onAuthStateChange: (cb: any) => {
+        authStateCallback = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      },
+      signInWithPassword: mockSignInWithPassword,
+      signUp: mockSignUp,
+      signOut: mockSignOut,
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    auth: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { id: '123' } } },
+      error: null,
+    });
+    mockSignInWithPassword.mockResolvedValue({ data: {}, error: null });
+    mockSignUp.mockResolvedValue({ data: {}, error: null });
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it('initializes with session', async () => {
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.user?.id).toBe('123');
+    expect(mockGetSession).toHaveBeenCalled();
+  });
+
+  it('signs in with email and password', async () => {
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.signIn('test@example.com', 'password');
+    });
+    expect(mockSignInWithPassword).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      password: 'password',
+    });
+  });
+
+  it('signs out and clears user', async () => {
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.signOut();
+      authStateCallback && authStateCallback('SIGNED_OUT', null);
+    });
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(result.current.user).toBeNull();
+  });
+});
+

--- a/src/hooks/useRequirePermission.test.tsx
+++ b/src/hooks/useRequirePermission.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { useRequirePermission } from './useRequirePermission';
+import { vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+const mockUsePermissions = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('./usePermissions', () => ({
+  usePermissions: () => mockUsePermissions(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe('useRequirePermission', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('redirects when user lacks required role', () => {
+    mockUsePermissions.mockReturnValue({
+      hasAnyRole: () => false,
+      loading: false,
+    });
+    renderHook(() => useRequirePermission({ roles: ['admin'] }));
+    expect(mockNavigate).toHaveBeenCalledWith('/unauthorized', { replace: true });
+  });
+
+  it('allows access when user has role', () => {
+    mockUsePermissions.mockReturnValue({
+      hasAnyRole: () => true,
+      loading: false,
+    });
+    const { result } = renderHook(() => useRequirePermission({ roles: ['admin'] }));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(result.current.hasAccess).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add useAuth hook tests covering initialization and sign in/out flow
- add permission guard tests for missing and allowed roles
- test onboarding protected route redirects and rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910b22b504832ca000698e99b9d787