### PR TITLE
Add indexes and cleanup for email verification tokens

### DIFF
--- a/supabase/migrations/20250730025418-96997d6d-3464-4a3a-9049-19f5f105984d.sql
+++ b/supabase/migrations/20250730025418-96997d6d-3464-4a3a-9049-19f5f105984d.sql
@@ -42,10 +42,25 @@ CREATE TABLE IF NOT EXISTS public.email_verification_tokens (
 -- Enable RLS on verification tokens
 ALTER TABLE public.email_verification_tokens ENABLE ROW LEVEL SECURITY;
 
+-- Add indexes to optimize lookups and cleanup
+CREATE INDEX IF NOT EXISTS email_verification_tokens_user_id_idx
+  ON public.email_verification_tokens (user_id);
+
+CREATE INDEX IF NOT EXISTS email_verification_tokens_expires_at_idx
+  ON public.email_verification_tokens (expires_at);
+
+-- Schedule daily cleanup of expired tokens at 3 AM UTC
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+SELECT cron.schedule(
+  'cleanup_expired_email_verification_tokens',
+  '0 3 * * *',
+  $$DELETE FROM public.email_verification_tokens WHERE expires_at < now()$$
+);
+
 -- Only system can manage verification tokens (no user access)
-CREATE POLICY "System only access to verification tokens" 
-ON public.email_verification_tokens 
-FOR ALL 
+CREATE POLICY "System only access to verification tokens"
+ON public.email_verification_tokens
+FOR ALL
 USING (false);
 
 -- 3. Create secure role assignment function


### PR DESCRIPTION
## Summary
- index `email_verification_tokens` by `user_id` and `expires_at`
- schedule nightly cleanup of expired verification tokens

## Testing
- `npm test` (no test files)
- `npm run lint` (fails: 2406 errors)

------
https://chatgpt.com/codex/tasks/task_e_689105e56e20832cbfd60d53d1871d10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system performance by optimizing database queries related to email verification tokens.
  * Added automated daily cleanup of expired email verification tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->