### PR TITLE
Add index on goals year column

### DIFF
--- a/supabase/migrations/20250801120000-add-year-column-to-goals.sql
+++ b/supabase/migrations/20250801120000-add-year-column-to-goals.sql
@@ -1,3 +1,6 @@
 -- Add computed year column to goals table
 ALTER TABLE public.goals
 ADD COLUMN IF NOT EXISTS year INTEGER GENERATED ALWAYS AS (extract(year from start_date)) STORED;
+
+-- Index for faster querying by year
+CREATE INDEX idx_goals_year ON public.goals(year);


### PR DESCRIPTION
## Summary
- add SQL index to goals table's new `year` column for efficient querying

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: 2873 problems, 2406 errors, 467 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68910607bca0832cafb5bd3898384238