### PR TITLE
feat: add login error handling

### DIFF
--- a/src/hooks/useAuthHandlers.ts
+++ b/src/hooks/useAuthHandlers.ts
@@ -177,7 +177,7 @@ export function useAuthHandlers({
     } catch (error: any) {
       logger.auth.error("Authentication error", error);
       const sanitizedError = sanitizeErrorMessage(error);
-      
+
       // Provide more specific error messages
       let userFriendlyMessage = sanitizedError;
       if (error.message?.includes("Invalid login credentials")) {
@@ -189,12 +189,8 @@ export function useAuthHandlers({
       } else if (error.message?.includes("Password should be at least")) {
         userFriendlyMessage = "Password should be at least 12 characters long.";
       }
-      
-      toast({
-        title: isSignUp ? "Sign Up Error" : "Log In Error",
-        description: userFriendlyMessage,
-        variant: "destructive",
-      });
+
+      throw new Error(userFriendlyMessage);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useAuthHandlers } from "@/hooks/useAuthHandlers";
+import { useToast } from "@/hooks/use-toast";
+
+const Login = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const { toast } = useToast();
+
+  const { handleSubmit } = useAuthHandlers({
+    isSignUp: false,
+    email,
+    password,
+    firstName: "",
+    lastName: "",
+    setIsLoading,
+  });
+
+  const onSubmit = async (e: React.FormEvent) => {
+    try {
+      await handleSubmit(e);
+    } catch (error) {
+      const description = error instanceof Error ? error.message : "An unexpected error occurred.";
+      toast({
+        title: "Log In Error",
+        description,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-6">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+        <Input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? "Loading..." : "Log In"}
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;
+


### PR DESCRIPTION
## Summary
- add login page with toast-based error banner
- propagate `useAuthHandlers` errors to the page

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Resolve error: typescript with invalid interface loaded as resolver)*

------
https://chatgpt.com/codex/tasks/task_e_68911742bfc4832c81edc2188e7d57a4