### PR TITLE
Refactor MagicPath goal creation flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.7.0",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.9.0",
@@ -127,6 +128,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -156,6 +171,176 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -176,6 +361,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+      "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/parser": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
@@ -192,6 +401,38 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
@@ -201,10 +442,44 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4162,6 +4437,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -4919,6 +5239,27 @@
         "react": ">= 16"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.10.2.tgz",
@@ -4932,6 +5273,13 @@
       "peerDependencies": {
         "vite": "^4 || ^5 || ^6 || ^7.0.0-beta.0"
       }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -5738,6 +6086,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -7090,6 +7445,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -8026,6 +8391,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -9133,6 +9511,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -11677,6 +12065,13 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",

--- a/src/components/magicpath/MagicPathGoalCreator.tsx
+++ b/src/components/magicpath/MagicPathGoalCreator.tsx
@@ -1,506 +1,86 @@
-import React, { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Target, Users, FileText, Calendar, CheckCircle, AlertCircle, TrendingUp, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useOptimizedEmployees } from '@/hooks/useOptimizedEmployees';
-import { useAuth } from '@/hooks/useAuth';
-import { useCurrentOrganization } from '@/hooks/useCurrentOrganization';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import ProgressIndicator from './ProgressIndicator';
-import EmployeeMultiSelectDropdown from './EmployeeMultiSelectDropdown';
-import GoalDetailsSection from './GoalDetailsSection';
-import { MagicPathEmployee, MagicPathGoalData, MagicPathGoalCreatorProps } from './types';
+import React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
-const MagicPathGoalCreator: React.FC<MagicPathGoalCreatorProps> = ({ onComplete }) => {
-  const [currentStep, setCurrentStep] = useState(1);
-  const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [goalData, setGoalData] = useState<MagicPathGoalData>({
-    selectedEmployees: [],
-    goalName: '',
-    description: '',
-    startDate: '',
-    endDate: '',
-    priority: 'Medium',
-    metrics: []
-  });
+import ProgressIndicator from "./ProgressIndicator";
+import { SelectEmployees } from "./steps/SelectEmployees";
+import { GoalDetails } from "./steps/GoalDetails";
+import { Review } from "./steps/Review";
+import { Success } from "./steps/Success";
+import { useMagicPathGoal } from "@/hooks/useMagicPathGoal";
+import type { MagicPathGoalCreatorProps } from "./types";
 
-  const { data: employees = [], isLoading: employeesLoading } = useOptimizedEmployees();
-  const { user } = useAuth();
-  const organizationState = useCurrentOrganization();
-  const organization = { id: organizationState.id };
-  const { toast } = useToast();
-  const totalSteps = 4;
+const MagicPathGoalCreator = ({ onComplete }: MagicPathGoalCreatorProps) => {
+  const {
+    currentStep,
+    goalData,
+    employees,
+    employeesLoading,
+    handleNext,
+    handleBack,
+    handleEmployeeSelection,
+    handleGoalDetailsChange,
+    canProceed,
+    createGoal,
+    isLoading,
+  } = useMagicPathGoal(onComplete);
 
-  // Transform Supabase employees to MagicPath format
-  const magicPathEmployees: MagicPathEmployee[] = employees.map(emp => ({
-    id: emp.id,
-    name: `${emp.profile?.first_name || ''} ${emp.profile?.last_name || ''}`.trim() || 'Unknown',
-    role: emp.job_title || 'No Role',
-    department: emp.department?.name || 'No Department',
-    avatar: emp.profile?.avatar_url || undefined
-  }));
-
-  const handleNext = () => {
-    if (currentStep < totalSteps) {
-      setCurrentStep(currentStep + 1);
-    }
-  };
-
-  const handleBack = () => {
-    if (currentStep > 1) {
-      setCurrentStep(currentStep - 1);
-    }
-  };
-
-  const handleEmployeeSelection = (employees: MagicPathEmployee[]) => {
-    setGoalData(prev => ({
-      ...prev,
-      selectedEmployees: employees
-    }));
-  };
-
-  const handleGoalDetailsChange = (field: keyof MagicPathGoalData, value: any) => {
-    setGoalData(prev => ({
-      ...prev,
-      [field]: value
-    }));
-  };
-
-  const canProceed = () => {
-    switch (currentStep) {
-      case 1:
-        return goalData.selectedEmployees.length > 0;
-      case 2:
-        return goalData.goalName.trim() !== '' && goalData.description.trim() !== '';
-      case 3:
-        return true;
-      case 4:
-        return true;
-      default:
-        return false;
-    }
-  };
-
-  const handleCreateGoal = async () => {
-    setIsLoading(true);
-    
-    try {
-      if (!user?.id || !organization?.id) {
-        throw new Error('User not authenticated or organization not found');
-      }
-
-      // Create goal in database using correct schema
-      const { data: goal, error: goalError } = await supabase
-        .from('goals')
-        .insert({
-          title: goalData.goalName,
-          description: goalData.description,
-          start_date: goalData.startDate,
-          due_date: goalData.endDate || goalData.startDate,
-          priority: goalData.priority.toLowerCase(),
-          status: 'active',
-          progress: 0,
-          created_by: user.id,
-          organization_id: organization.id,
-          year: new Date().getFullYear(),
-          type: 'team_goal'
-        })
-        .select()
-        .single();
-
-      if (goalError) throw goalError;
-
-      // Create goal assignments for selected employees
-      if (goal && goalData.selectedEmployees.length > 0) {
-        const assignments = goalData.selectedEmployees.map(emp => ({
-          goal_id: goal.id,
-          employee_id: emp.id,
-          assigned_by: user.id
-        }));
-
-        const { error: assignmentError } = await supabase
-          .from('goal_assignments')
-          .insert(assignments);
-
-        if (assignmentError) throw assignmentError;
-      }
-
-      setShowSuccess(true);
-      toast({
-        title: "Goal Created Successfully!",
-        description: `Created "${goalData.goalName}" with ${goalData.selectedEmployees.length} team members.`,
-      });
-
-      // Auto-redirect after success
-      setTimeout(() => {
-        if (onComplete) {
-          onComplete(goalData);
-        }
-      }, 2000);
-
-    } catch (error) {
-      console.error('Error creating goal:', error);
-      toast({
-        title: "Error Creating Goal",
-        description: "There was a problem creating the goal. Please try again.",
-        variant: "destructive"
-      });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const renderStepContent = () => {
-    if (showSuccess) {
-      return (
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          className="text-center py-12"
-        >
-          <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-            <CheckCircle className="h-8 w-8 text-green-600" />
-          </div>
-          <h2 className="text-2xl font-bold text-foreground mb-2">Goal Created Successfully!</h2>
-          <p className="text-muted-foreground mb-6">
-            Your goal has been created and assigned to {goalData.selectedEmployees.length} team member{goalData.selectedEmployees.length !== 1 ? 's' : ''}.
-          </p>
-          <div className="bg-muted/30 rounded-lg p-4 text-left max-w-md mx-auto">
-            <h3 className="font-semibold text-foreground mb-2">{goalData.goalName}</h3>
-            <p className="text-sm text-muted-foreground mb-3">{goalData.description}</p>
-            <div className="flex flex-wrap gap-2">
-              {goalData.selectedEmployees.map(employee => (
-                <span key={employee.id} className="bg-primary/10 text-primary px-2 py-1 rounded-full text-xs">
-                  {employee.name}
-                </span>
-              ))}
-            </div>
-          </div>
-        </motion.div>
-      );
-    }
-
+  const renderStep = () => {
     switch (currentStep) {
       case 1:
         return (
-          <div className="space-y-8">
-            <div className="flex items-center space-x-4">
-              <div className="p-3 bg-primary/10 rounded-xl">
-                <Users className="h-6 w-6 text-primary" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-bold text-foreground">Select Team Members</h2>
-                <p className="text-muted-foreground">Choose employees who will work on this goal</p>
-              </div>
-            </div>
-            
-            {employeesLoading ? (
-              <div className="text-center py-12">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-                <p className="text-muted-foreground">Loading employees...</p>
-              </div>
-            ) : magicPathEmployees.length === 0 ? (
-              <div className="text-center py-12">
-                <AlertCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                <h3 className="text-lg font-semibold text-foreground mb-2">No employees found</h3>
-                <p className="text-muted-foreground">
-                  You need to add employees to your team before creating goals.
-                </p>
-              </div>
-            ) : (
-              <EmployeeMultiSelectDropdown
-                employees={magicPathEmployees}
-                selectedEmployees={goalData.selectedEmployees}
-                onSelectionChange={handleEmployeeSelection}
-              />
-            )}
-          </div>
+          <SelectEmployees
+            employees={employees}
+            selectedEmployees={goalData.selectedEmployees}
+            loading={employeesLoading}
+            onSelect={handleEmployeeSelection}
+          />
         );
-
       case 2:
         return (
-          <div className="space-y-8">
-            <div className="flex items-center space-x-4">
-              <div className="p-3 bg-primary/10 rounded-xl">
-                <FileText className="h-6 w-6 text-primary" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-bold text-foreground">Goal Details</h2>
-                <p className="text-muted-foreground">Define the goal name and description</p>
-              </div>
-            </div>
-            
-            <GoalDetailsSection
-              goalData={goalData}
-              onGoalDetailsChange={handleGoalDetailsChange}
-              step="details"
-            />
-          </div>
+          <GoalDetails goalData={goalData} onChange={handleGoalDetailsChange} />
         );
-
       case 3:
-        return (
-          <div className="space-y-8">
-            <div className="flex items-center space-x-4">
-              <div className="p-3 bg-primary/10 rounded-xl">
-                <Calendar className="h-6 w-6 text-primary" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-bold text-foreground">Schedule & Priority</h2>
-                <p className="text-muted-foreground">Set timeline and priority level</p>
-              </div>
-            </div>
-            
-            <div className="space-y-6">
-              {/* Date Selection */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="space-y-2">
-                  <label htmlFor="startDate" className="text-sm font-medium text-foreground">
-                    Due Date
-                  </label>
-                  <input
-                    id="startDate"
-                    type="date"
-                    value={goalData.startDate}
-                    onChange={(e) => handleGoalDetailsChange('startDate', e.target.value)}
-                    className="w-full px-4 py-3 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Leave empty to set as immediately due
-                  </p>
-                </div>
-
-                <div className="space-y-2">
-                  <label htmlFor="priority" className="text-sm font-medium text-foreground">
-                    Priority Level
-                  </label>
-                  <select
-                    id="priority"
-                    value={goalData.priority}
-                    onChange={(e) => handleGoalDetailsChange('priority', e.target.value as 'Low' | 'Medium' | 'High')}
-                    className="w-full px-4 py-3 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors"
-                  >
-                    <option value="Low">Low Priority</option>
-                    <option value="Medium">Medium Priority</option>
-                    <option value="High">High Priority</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-
+        return <Review goalData={goalData} />;
       case 4:
-        return (
-          <div className="space-y-8">
-            <div className="flex items-center space-x-4">
-              <div className="p-3 bg-primary/10 rounded-xl">
-                <Target className="h-6 w-6 text-primary" />
-              </div>
-              <div>
-                <h2 className="text-2xl font-bold text-foreground">Goal Preview</h2>
-                <p className="text-muted-foreground">Review and confirm goal details</p>
-              </div>
-            </div>
-            
-            {/* Goal Preview Content */}
-            <div className="space-y-6">
-              {/* Goal Title & Description */}
-              <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
-                <div className="space-y-4">
-                  <h3 className="text-2xl font-bold text-foreground leading-tight">{goalData.goalName}</h3>
-                  <p className="text-muted-foreground text-base leading-relaxed">{goalData.description}</p>
-                </div>
-              </div>
-
-              {/* Assigned Team Members */}
-              <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
-                <div className="flex items-center space-x-2 mb-6">
-                  <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
-                    <Users className="h-4 w-4 text-blue-600" />
-                  </div>
-                  <h4 className="font-semibold text-foreground">Assigned Team Members</h4>
-                  <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
-                    {goalData.selectedEmployees.length}
-                  </span>
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {goalData.selectedEmployees.map(employee => (
-                    <div key={employee.id} className="flex items-center space-x-3 p-4 bg-background/70 rounded-lg border border-border/30">
-                      <div className="w-12 h-12 bg-gradient-to-br from-primary/10 to-primary/20 rounded-full flex items-center justify-center flex-shrink-0">
-                        <span className="text-sm font-bold text-primary">
-                          {employee.name.split(' ').map(n => n[0]).join('')}
-                        </span>
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="font-semibold text-foreground text-sm truncate">{employee.name}</p>
-                        <p className="text-xs text-muted-foreground truncate">{employee.role}</p>
-                        <p className="text-xs text-primary font-medium">{employee.department}</p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Success Metrics */}
-              {goalData.metrics.filter(m => m.trim()).length > 0 && (
-                <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
-                  <div className="flex items-center space-x-2 mb-4">
-                    <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
-                      <TrendingUp className="h-4 w-4 text-purple-600" />
-                    </div>
-                    <h4 className="font-semibold text-foreground">Success Metrics</h4>
-                    <span className="text-xs bg-purple-100 text-purple-800 px-2 py-1 rounded-full">
-                      {goalData.metrics.filter(m => m.trim()).length}
-                    </span>
-                  </div>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                    {goalData.metrics.filter(m => m.trim()).map((metric, index) => (
-                      <div key={index} className="flex items-start space-x-3 p-3 bg-background/70 rounded-lg border border-border/30">
-                        <div className="w-6 h-6 bg-primary/10 rounded-full flex items-center justify-center mt-0.5 flex-shrink-0">
-                          <span className="text-xs font-bold text-primary">{index + 1}</span>
-                        </div>
-                        <p className="text-sm text-foreground leading-relaxed">{metric}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Due Date & Priority Level */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm text-center">
-                  <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                    <Calendar className="h-6 w-6 text-green-600" />
-                  </div>
-                  <h4 className="font-semibold text-foreground mb-1">Due Date</h4>
-                  <p className="text-lg font-bold text-primary mb-1">
-                    {goalData.startDate ? new Date(goalData.startDate).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric'
-                    }) : 'Immediately'}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    {goalData.startDate ? 'Target date' : 'Due now'}
-                  </p>
-                </div>
-
-                <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm text-center">
-                  <div className={cn(
-                    "w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3",
-                    goalData.priority === 'High' && "bg-red-100",
-                    goalData.priority === 'Medium' && "bg-yellow-100",
-                    goalData.priority === 'Low' && "bg-green-100"
-                  )}>
-                    <div className={cn(
-                      "w-3 h-3 rounded-full",
-                      goalData.priority === 'High' && "bg-red-500",
-                      goalData.priority === 'Medium' && "bg-yellow-500",
-                      goalData.priority === 'Low' && "bg-green-500"
-                    )} />
-                  </div>
-                  <h4 className="font-semibold text-foreground mb-1">Priority</h4>
-                  <p className="text-lg font-bold text-primary mb-1">{goalData.priority}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {goalData.priority === 'High' && 'Urgent'}
-                    {goalData.priority === 'Medium' && 'Standard'}
-                    {goalData.priority === 'Low' && 'Flexible'}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-
+        return <Success goalData={goalData} />;
       default:
         return null;
     }
   };
 
   return (
-    <div className="space-y-4 sm:space-y-6">
-      {/* Progress Indicator */}
-      <div className="mb-8">
-        <ProgressIndicator currentStep={currentStep} totalSteps={totalSteps} />
-      </div>
-
-      {/* Main Content */}
-      <div className="bg-card border rounded-xl p-8 shadow-sm">
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={currentStep}
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -20 }}
-            transition={{ duration: 0.3 }}
-          >
-            {renderStepContent()}
-          </motion.div>
-        </AnimatePresence>
-
-        {/* Navigation */}
-        <div className="flex justify-between items-center pt-8 mt-8 border-t">
+    <div className="max-w-3xl mx-auto p-6 bg-background rounded-xl border border-border">
+      <ProgressIndicator currentStep={currentStep} totalSteps={4} />
+      {renderStep()}
+      {currentStep < 4 && (
+        <div className="flex justify-between mt-8">
           <button
             onClick={handleBack}
-            disabled={currentStep === 1 || isLoading}
-            className={cn(
-              "flex items-center space-x-2 px-6 py-3 rounded-xl font-medium transition-all duration-200",
-              currentStep === 1 || isLoading
-                ? "text-muted-foreground cursor-not-allowed"
-                : "text-foreground hover:bg-muted/50"
-            )}
+            disabled={currentStep === 1}
+            className="flex items-center text-sm disabled:opacity-50"
           >
-            <ChevronLeft className="h-4 w-4" />
-            <span>Back</span>
+            <ChevronLeft className="h-4 w-4 mr-1" /> Back
           </button>
-
-          <div className="flex space-x-3">
-            {currentStep < totalSteps && (
-              <button
-                onClick={handleNext}
-                disabled={!canProceed() || isLoading}
-                className={cn(
-                  "flex items-center space-x-2 px-8 py-3 rounded-xl font-medium transition-all duration-200",
-                  canProceed() && !isLoading
-                    ? "bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg"
-                    : "bg-muted text-muted-foreground cursor-not-allowed"
-                )}
-              >
-                <span>Next</span>
-                <ChevronRight className="h-4 w-4" />
-              </button>
-            )}
-
-            {currentStep === totalSteps && (
-              <button
-                onClick={handleCreateGoal}
-                disabled={!canProceed() || isLoading}
-                className={cn(
-                  "flex items-center space-x-2 px-8 py-3 rounded-xl font-medium transition-all duration-200",
-                  canProceed() && !isLoading
-                    ? "bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg"
-                    : "bg-muted text-muted-foreground cursor-not-allowed"
-                )}
-              >
-                {isLoading ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>Creating Goal...</span>
-                  </>
-                ) : (
-                  <>
-                    <Target className="h-4 w-4" />
-                    <span>Create Goal</span>
-                  </>
-                )}
-              </button>
-            )}
-          </div>
+          {currentStep === 3 ? (
+            <button
+              onClick={createGoal}
+              disabled={isLoading}
+              className="flex items-center text-sm"
+            >
+              {isLoading ? "Creating..." : "Create Goal"}
+              <ChevronRight className="h-4 w-4 ml-1" />
+            </button>
+          ) : (
+            <button
+              onClick={handleNext}
+              disabled={!canProceed()}
+              className="flex items-center text-sm disabled:opacity-50"
+            >
+              Next <ChevronRight className="h-4 w-4 ml-1" />
+            </button>
+          )}
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/magicpath/steps/GoalDetails.tsx
+++ b/src/components/magicpath/steps/GoalDetails.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import GoalDetailsSection from "../GoalDetailsSection";
+import type { MagicPathGoalData } from "../types";
+
+interface GoalDetailsProps {
+  goalData: MagicPathGoalData;
+  onChange: (field: keyof MagicPathGoalData, value: string | string[]) => void;
+}
+
+export const GoalDetails = ({ goalData, onChange }: GoalDetailsProps) => {
+  return (
+    <div className="space-y-8">
+      <GoalDetailsSection
+        goalData={goalData}
+        onGoalDetailsChange={onChange}
+        step="details"
+      />
+      <GoalDetailsSection
+        goalData={goalData}
+        onGoalDetailsChange={onChange}
+        step="timeline"
+      />
+    </div>
+  );
+};
+
+export default GoalDetails;

--- a/src/components/magicpath/steps/Review.tsx
+++ b/src/components/magicpath/steps/Review.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { Users, Calendar, TrendingUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+import type { MagicPathGoalData } from "../types";
+
+interface ReviewProps {
+  goalData: MagicPathGoalData;
+}
+
+export const Review = ({ goalData }: ReviewProps) => {
+  return (
+    <div className="space-y-6">
+      <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
+        <div className="space-y-4">
+          <h3 className="text-2xl font-bold text-foreground leading-tight">
+            {goalData.goalName}
+          </h3>
+          <p className="text-muted-foreground text-base leading-relaxed">
+            {goalData.description}
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
+        <div className="flex items-center space-x-2 mb-6">
+          <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+            <Users className="h-4 w-4 text-blue-600" />
+          </div>
+          <h4 className="font-semibold text-foreground">Assigned Team Members</h4>
+          <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
+            {goalData.selectedEmployees.length}
+          </span>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {goalData.selectedEmployees.map((employee) => (
+            <div
+              key={employee.id}
+              className="flex items-center space-x-3 p-4 bg-background/70 rounded-lg border border-border/30"
+            >
+              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center flex-shrink-0">
+                <span className="text-sm font-bold text-primary">
+                  {employee.name
+                    .split(" ")
+                    .map((n) => n[0])
+                    .join("")}
+                </span>
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="font-semibold text-foreground text-sm truncate">
+                  {employee.name}
+                </p>
+                <p className="text-xs text-muted-foreground truncate">
+                  {employee.role}
+                </p>
+                <p className="text-xs text-primary font-medium">
+                  {employee.department}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {goalData.metrics.filter((m) => m.trim()).length > 0 && (
+        <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm">
+          <div className="flex items-center space-x-2 mb-4">
+            <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
+              <TrendingUp className="h-4 w-4 text-purple-600" />
+            </div>
+            <h4 className="font-semibold text-foreground">Success Metrics</h4>
+            <span className="text-xs bg-purple-100 text-purple-800 px-2 py-1 rounded-full">
+              {goalData.metrics.filter((m) => m.trim()).length}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {goalData.metrics
+              .filter((m) => m.trim())
+              .map((metric, index) => (
+                <div
+                  key={index}
+                  className="flex items-start space-x-3 p-3 bg-background/70 rounded-lg border border-border/30"
+                >
+                  <div className="w-6 h-6 bg-primary/10 rounded-full flex items-center justify-center mt-0.5 flex-shrink-0">
+                    <span className="text-xs font-bold text-primary">
+                      {index + 1}
+                    </span>
+                  </div>
+                  <p className="text-sm text-foreground leading-relaxed">
+                    {metric}
+                  </p>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm text-center">
+          <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
+            <Calendar className="h-6 w-6 text-green-600" />
+          </div>
+          <h4 className="font-semibold text-foreground mb-1">Due Date</h4>
+          <p className="text-lg font-bold text-primary mb-1">
+            {goalData.startDate
+              ? new Date(goalData.startDate).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })
+              : "Immediately"}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {goalData.startDate ? "Target date" : "Due now"}
+          </p>
+        </div>
+
+        <div className="bg-background/50 backdrop-blur-sm rounded-xl p-6 border border-border/30 shadow-sm text-center">
+          <div
+            className={cn(
+              "w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3",
+              goalData.priority === "High" && "bg-red-100",
+              goalData.priority === "Medium" && "bg-yellow-100",
+              goalData.priority === "Low" && "bg-green-100"
+            )}
+          >
+            <div
+              className={cn(
+                "w-3 h-3 rounded-full",
+                goalData.priority === "High" && "bg-red-500",
+                goalData.priority === "Medium" && "bg-yellow-500",
+                goalData.priority === "Low" && "bg-green-500"
+              )}
+            />
+          </div>
+          <h4 className="font-semibold text-foreground mb-1">Priority Level</h4>
+          <p className="text-lg font-bold text-primary mb-1">
+            {goalData.priority}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Review;

--- a/src/components/magicpath/steps/SelectEmployees.tsx
+++ b/src/components/magicpath/steps/SelectEmployees.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { AlertCircle } from "lucide-react";
+
+import EmployeeMultiSelectDropdown from "../EmployeeMultiSelectDropdown";
+import type { MagicPathEmployee } from "../types";
+
+interface SelectEmployeesProps {
+  employees: MagicPathEmployee[];
+  selectedEmployees: MagicPathEmployee[];
+  loading: boolean;
+  onSelect: (employees: MagicPathEmployee[]) => void;
+}
+
+export const SelectEmployees = ({
+  employees,
+  selectedEmployees,
+  loading,
+  onSelect,
+}: SelectEmployeesProps) => {
+  if (loading) {
+    return <div className="text-center p-8">Loading employees...</div>;
+  }
+
+  if (employees.length === 0) {
+    return (
+      <div className="text-center p-8 text-muted-foreground">
+        <AlertCircle className="h-6 w-6 mx-auto mb-2" />
+        No employees found
+      </div>
+    );
+  }
+
+  return (
+    <EmployeeMultiSelectDropdown
+      employees={employees}
+      selectedEmployees={selectedEmployees}
+      onSelectionChange={onSelect}
+    />
+  );
+};
+
+export default SelectEmployees;

--- a/src/components/magicpath/steps/Success.tsx
+++ b/src/components/magicpath/steps/Success.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { CheckCircle } from "lucide-react";
+
+import type { MagicPathGoalData } from "../types";
+
+interface SuccessProps {
+  goalData: MagicPathGoalData;
+}
+
+export const Success = ({ goalData }: SuccessProps) => {
+  return (
+    <div className="text-center py-12">
+      <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
+        <CheckCircle className="h-8 w-8 text-green-600" />
+      </div>
+      <h2 className="text-2xl font-bold text-foreground mb-2">Goal Created Successfully!</h2>
+      <p className="text-muted-foreground mb-6">
+        Your goal has been created and assigned to {goalData.selectedEmployees.length} team member{goalData.selectedEmployees.length !== 1 ? "s" : ""}.
+      </p>
+    </div>
+  );
+};
+
+export default Success;

--- a/src/hooks/useMagicPathGoal.test.ts
+++ b/src/hooks/useMagicPathGoal.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, beforeEach, expect } from "vitest";
+
+import { useMagicPathGoal } from "./useMagicPathGoal";
+
+const { goalInsert, goalSelect, goalSingle, assignmentInsert, toast } = vi.hoisted(() => ({
+  goalSingle: vi.fn(),
+  goalSelect: vi.fn().mockReturnValue({ single: () => goalSingle() }),
+  goalInsert: vi.fn().mockReturnValue({ select: () => goalSelect() }),
+  assignmentInsert: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: (table: string) => {
+      if (table === "goals") {
+        return { insert: goalInsert };
+      }
+      if (table === "goal_assignments") {
+        return { insert: assignmentInsert };
+      }
+      return {};
+    },
+  },
+}));
+
+vi.mock("./useOptimizedEmployees", () => ({
+  useOptimizedEmployees: () => ({
+    data: [
+      {
+        id: "emp1",
+        profile: { first_name: "John", last_name: "Doe", avatar_url: "" },
+        job_title: "Dev",
+        department: { name: "Eng" },
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("./useAuth", () => ({
+  useAuth: () => ({ user: { id: "user1" } }),
+}));
+
+vi.mock("./useCurrentOrganization", () => ({
+  useCurrentOrganization: () => ({ id: "org1" }),
+}));
+
+vi.mock("./use-toast", () => ({
+  useToast: () => ({ toast }),
+}));
+
+describe("useMagicPathGoal", () => {
+  beforeEach(() => {
+    goalInsert.mockClear();
+    goalSelect.mockClear();
+    goalSingle.mockReset();
+    assignmentInsert.mockClear();
+    toast.mockClear();
+    goalSingle.mockResolvedValue({ data: { id: "goal123" }, error: null });
+    assignmentInsert.mockResolvedValue({ error: null });
+  });
+
+  it("creates goal successfully", async () => {
+    const { result } = renderHook(() => useMagicPathGoal());
+
+    act(() => {
+      result.current.handleEmployeeSelection([
+        { id: "emp1", name: "John Doe", role: "Dev", department: "Eng" },
+      ]);
+      result.current.handleGoalDetailsChange("goalName", "Test Goal");
+      result.current.handleGoalDetailsChange("description", "Desc");
+    });
+
+    await act(async () => {
+      await result.current.createGoal();
+    });
+
+    expect(goalInsert).toHaveBeenCalled();
+    expect(assignmentInsert).toHaveBeenCalled();
+    expect(result.current.currentStep).toBe(4);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Goal Created Successfully!" }),
+    );
+  });
+
+  it("handles creation errors", async () => {
+    goalSingle.mockResolvedValue({ data: null, error: new Error("fail") });
+
+    const { result } = renderHook(() => useMagicPathGoal());
+    act(() => {
+      result.current.handleEmployeeSelection([
+        { id: "emp1", name: "John Doe", role: "Dev", department: "Eng" },
+      ]);
+      result.current.handleGoalDetailsChange("goalName", "Test Goal");
+      result.current.handleGoalDetailsChange("description", "Desc");
+    });
+
+    await act(async () => {
+      await result.current.createGoal();
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.currentStep).toBe(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    );
+  });
+});

--- a/src/hooks/useMagicPathGoal.ts
+++ b/src/hooks/useMagicPathGoal.ts
@@ -1,0 +1,148 @@
+import { useState } from "react";
+
+import { useOptimizedEmployees } from "./useOptimizedEmployees";
+import { useAuth } from "./useAuth";
+import { useCurrentOrganization } from "./useCurrentOrganization";
+import { useToast } from "./use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import type {
+  MagicPathEmployee,
+  MagicPathGoalData,
+  MagicPathGoalCreatorProps,
+} from "@/components/magicpath/types";
+
+const initialGoalData: MagicPathGoalData = {
+  selectedEmployees: [],
+  goalName: "",
+  description: "",
+  startDate: "",
+  endDate: "",
+  priority: "Medium",
+  metrics: [],
+};
+
+export const useMagicPathGoal = (
+  onComplete?: MagicPathGoalCreatorProps["onComplete"],
+) => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [goalData, setGoalData] = useState<MagicPathGoalData>(initialGoalData);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: employees = [], isLoading: employeesLoading } =
+    useOptimizedEmployees();
+  const { user } = useAuth();
+  const organization = useCurrentOrganization();
+  const { toast } = useToast();
+
+  const magicPathEmployees: MagicPathEmployee[] = employees.map((emp) => ({
+    id: emp.id,
+    name:
+      `${emp.profile?.first_name || ""} ${emp.profile?.last_name || ""}`.trim() ||
+      "Unknown",
+    role: emp.job_title || "No Role",
+    department: emp.department?.name || "No Department",
+    avatar: emp.profile?.avatar_url || undefined,
+  }));
+
+  const handleEmployeeSelection = (selected: MagicPathEmployee[]) => {
+    setGoalData((prev) => ({ ...prev, selectedEmployees: selected }));
+  };
+
+  const handleGoalDetailsChange = (
+    field: keyof MagicPathGoalData,
+    value: string | string[],
+  ) => {
+    setGoalData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleNext = () => setCurrentStep((s) => s + 1);
+  const handleBack = () => setCurrentStep((s) => Math.max(1, s - 1));
+
+  const canProceed = () => {
+    if (currentStep === 1) {
+      return goalData.selectedEmployees.length > 0;
+    }
+    if (currentStep === 2) {
+      return goalData.goalName.trim() !== "" && goalData.description.trim() !== "";
+    }
+    return true;
+  };
+
+  const createGoal = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      if (!user?.id || !organization?.id) {
+        throw new Error("User not authenticated or organization not found");
+      }
+
+      const { data: goal, error: goalError } = await supabase
+        .from("goals")
+        .insert({
+          title: goalData.goalName,
+          description: goalData.description,
+          start_date: goalData.startDate,
+          due_date: goalData.endDate || goalData.startDate,
+          priority: goalData.priority.toLowerCase(),
+          status: "active",
+          progress: 0,
+          created_by: user.id,
+          organization_id: organization.id,
+          year: new Date().getFullYear(),
+          type: "team_goal",
+        })
+        .select()
+        .single();
+
+      if (goalError) throw goalError;
+
+      if (goal && goalData.selectedEmployees.length > 0) {
+        const assignments = goalData.selectedEmployees.map((emp) => ({
+          goal_id: goal.id,
+          employee_id: emp.id,
+          assigned_by: user.id,
+        }));
+        const { error: assignmentError } = await supabase
+          .from("goal_assignments")
+          .insert(assignments);
+        if (assignmentError) throw assignmentError;
+      }
+
+      setCurrentStep(4);
+      toast({
+        title: "Goal Created Successfully!",
+        description: `Created "${goalData.goalName}" with ${goalData.selectedEmployees.length} team members.`,
+      });
+      setTimeout(() => {
+        onComplete?.(goalData);
+      }, 2000);
+    } catch (e) {
+      setError("There was a problem creating the goal.");
+      toast({
+        title: "Error Creating Goal",
+        description: "There was a problem creating the goal. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    currentStep,
+    goalData,
+    employees: magicPathEmployees,
+    employeesLoading,
+    isLoading,
+    error,
+    handleNext,
+    handleBack,
+    handleEmployeeSelection,
+    handleGoalDetailsChange,
+    canProceed,
+    createGoal,
+  };
+};
+
+export default useMagicPathGoal;


### PR DESCRIPTION
## Summary
- abstract goal creation logic and employee loading into `useMagicPathGoal`
- split goal creator into dedicated step components
- cover goal creation success and error paths with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689276f93a0c832cb59a6d06fedea606