### PR TITLE
feat: add notification events and real-time system

### DIFF
--- a/src/components/appraisals/NotificationSystem.tsx
+++ b/src/components/appraisals/NotificationSystem.tsx
@@ -6,6 +6,8 @@ import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { AlertCircle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
 
 export interface NotificationProps {
   type: 'success' | 'error' | 'info';
@@ -13,30 +15,74 @@ export interface NotificationProps {
 }
 
 interface NotificationSystemProps {
-  notification: NotificationProps | null;
+  notification?: NotificationProps | null;
 }
 
 export default function NotificationSystem({ notification }: NotificationSystemProps) {
+  const { user } = useAuth();
+  const [messages, setMessages] = React.useState<NotificationProps[]>([]);
+
+  React.useEffect(() => {
+    if (notification) {
+      setMessages(prev => [...prev, notification]);
+    }
+  }, [notification]);
+
+  React.useEffect(() => {
+    if (!user?.id) return;
+
+    const channel = supabase
+      .channel(`notifications-user-${user.id}`)
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${user.id}` },
+        payload => {
+          const data: any = payload.new;
+          setMessages(prev => [
+            ...prev,
+            { type: data.type || 'info', message: data.payload?.message || data.message || '' }
+          ]);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user?.id]);
+
+  React.useEffect(() => {
+    if (messages.length === 0) return;
+    const timer = setTimeout(() => {
+      setMessages(prev => prev.slice(1));
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [messages]);
+
   return (
     <AnimatePresence>
-      {notification && (
-        <motion.div 
+      {messages.map((n, index) => (
+        <motion.div
+          key={index}
           initial={{ opacity: 0, y: -50 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -50 }}
-          className="fixed top-4 right-4 z-toast"
+          className="fixed right-4 z-toast"
+          style={{ top: 16 + index * 80 }}
         >
-          <Alert className={cn(
-            "w-96 shadow-lg",
-            notification.type === 'success' && "border-green-500 bg-green-50",
-            notification.type === 'error' && "border-red-500 bg-red-50",
-            notification.type === 'info' && "border-blue-500 bg-blue-50"
-          )}>
+          <Alert
+            className={cn(
+              'w-96 shadow-lg',
+              n.type === 'success' && 'border-green-500 bg-green-50',
+              n.type === 'error' && 'border-red-500 bg-red-50',
+              n.type === 'info' && 'border-blue-500 bg-blue-50'
+            )}
+          >
             <AlertCircle className="h-4 w-4" />
-            <AlertDescription>{notification.message}</AlertDescription>
+            <AlertDescription>{n.message}</AlertDescription>
           </Alert>
         </motion.div>
-      )}
+      ))}
     </AnimatePresence>
   );
 }

--- a/src/components/appraisals/ReviewAndSignOffStep.tsx
+++ b/src/components/appraisals/ReviewAndSignOffStep.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { useRoleBasedNavigation } from "@/hooks/useRoleBasedNavigation";
 import DigitalSignatureModal from "./DigitalSignatureModal";
+import { notifyAppraisalEvent, logAuditEvent } from '@/hooks/useAppraisals';
 
 export interface Goal {
   id: string;
@@ -502,6 +503,8 @@ export default function ReviewAndSignOffStep({
           onSuccess={(signatureDataUrl) => {
             setShowSignatureModal(false);
             appraisalData.signatures.appraiser = "Signed";
+            void notifyAppraisalEvent(appraisalData.employeeId, 'signature_completed', { signature: signatureDataUrl });
+            void logAuditEvent(appraisalData.employeeId, 'signature_completed', {});
             onSubmit();
           }}
         />


### PR DESCRIPTION
## Summary
- add notifyAppraisalEvent and logAuditEvent helpers with edge-function email support and overdue checks
- trigger notifications and audit logs on appraisal submission and signature completion
- subscribe to user-specific Supabase notifications in NotificationSystem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689277243130832ca889acd02afe96fd