### PR TITLE
feat: add employee invitation and claim logic

### DIFF
--- a/src/hooks/useAuthProfile.ts
+++ b/src/hooks/useAuthProfile.ts
@@ -10,11 +10,14 @@ export const useAuthProfile = () => {
 
   useEffect(() => {
     const handleProfileClaim = async () => {
-      if (!user?.email) return;
+      if (!user?.id) return;
+
+      const token = (user.user_metadata as any)?.invitation_token;
+      if (!token) return;
 
       try {
-        const result = await claimProfile(user.email, user.id);
-        
+        const result = await claimProfile(token, user.id);
+
         if (result.success) {
           toast({
             title: "Profile Linked",
@@ -27,11 +30,10 @@ export const useAuthProfile = () => {
       }
     };
 
-    // Only try to claim profile on first login/signup
     if (user) {
       handleProfileClaim();
     }
-  }, [user?.id, user?.email, claimProfile, toast]);
+  }, [user, claimProfile, toast]);
 
   return {};
 };

--- a/src/hooks/useEmployeeInvitation.test.ts
+++ b/src/hooks/useEmployeeInvitation.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEmployeeInvitation } from './useEmployeeInvitation';
+
+const { mockGetUser, mockFrom, mockInvoke } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    functions: { invoke: mockInvoke },
+  },
+}));
+
+describe('useEmployeeInvitation', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockFrom.mockReset();
+    mockInvoke.mockReset();
+  });
+
+  it('invites employee and sends email', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user1' } }, error: null });
+
+    const profileChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { organization_id: 'org1' }, error: null }),
+    };
+
+    const insertChain = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { invitation_token: 'token123' }, error: null }),
+    };
+
+    mockFrom
+      .mockReturnValueOnce(profileChain)
+      .mockReturnValueOnce(insertChain);
+
+    mockInvoke.mockResolvedValue({ data: { success: true }, error: null });
+
+    const { result } = renderHook(() => useEmployeeInvitation());
+    let res;
+    await act(async () => {
+      res = await result.current.inviteEmployee({
+        email: 'test@example.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        jobTitle: 'Engineer',
+      });
+    });
+
+    expect(res.success).toBe(true);
+    expect(mockInvoke).toHaveBeenCalledWith('send-account-welcome', {
+      body: { email: 'test@example.com', firstName: 'John', lastName: 'Doe' },
+    });
+  });
+
+  it('fails to claim profile when token expired', async () => {
+    const expiredChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 'emp1', invited_at: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(), user_id: null },
+        error: null,
+      }),
+    };
+
+    mockFrom.mockReturnValueOnce(expiredChain);
+
+    const { result } = renderHook(() => useEmployeeInvitation());
+    let res;
+    await act(async () => {
+      res = await result.current.claimProfile('token123', 'user1');
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/expired/i);
+  });
+
+  it('fails to claim profile with invalid token', async () => {
+    const invalidChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+    };
+
+    mockFrom.mockReturnValueOnce(invalidChain);
+
+    const { result } = renderHook(() => useEmployeeInvitation());
+    let res;
+    await act(async () => {
+      res = await result.current.claimProfile('badtoken', 'user1');
+    });
+
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/invalid/i);
+  });
+});

--- a/src/hooks/useEmployeeInvitation.ts
+++ b/src/hooks/useEmployeeInvitation.ts
@@ -29,29 +29,94 @@ export const useEmployeeInvitation = () => {
         throw new Error('Could not find user profile');
       }
 
-      // Create the invited employee profile - simplified for now
-      // This needs proper implementation with email invitations
-      return { success: false, error: 'Employee invitation feature not fully implemented yet' };
+      // Insert the invited employee profile
+      const { data: invited, error: insertError } = await supabase
+        .from('employee_info')
+        .insert({
+          email: employeeData.email,
+          first_name: employeeData.firstName,
+          last_name: employeeData.lastName,
+          job_title: employeeData.jobTitle,
+          department_id: employeeData.departmentId,
+          division_id: employeeData.divisionId,
+          role_id: employeeData.roleId,
+          organization_id: profile.organization_id,
+          status: 'invited'
+        })
+        .select('invitation_token')
+        .single();
 
+      if (insertError || !invited) {
+        throw new Error('Failed to create employee invitation');
+      }
+
+      // Send welcome email
+      const { error: emailError } = await supabase.functions.invoke(
+        'send-account-welcome',
+        {
+          body: {
+            email: employeeData.email,
+            firstName: employeeData.firstName,
+            lastName: employeeData.lastName
+          }
+        }
+      );
+
+      if (emailError) {
+        throw new Error('Failed to send invitation email');
+      }
+
+      return { success: true, token: invited.invitation_token };
     } catch (error) {
       console.error('Failed to invite employee:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error occurred' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
       };
     }
   };
 
-  const claimProfile = async (email: string, userId: string) => {
+  const claimProfile = async (token: string, userId: string) => {
     try {
-      // For now, just return not implemented
-      // This functionality needs to be implemented with proper email tracking
-      return { success: false, error: 'Profile claiming not implemented yet' };
+      const { data: invited, error: fetchError } = await supabase
+        .from('employee_info')
+        .select('*')
+        .eq('invitation_token', token)
+        .single();
+
+      if (fetchError || !invited) {
+        throw new Error('Invalid or expired invitation token');
+      }
+
+      const invitedAt = new Date(invited.invited_at);
+      const expiration = new Date(invitedAt.getTime() + 7 * 24 * 60 * 60 * 1000);
+      if (new Date() > expiration) {
+        throw new Error('Invitation token has expired');
+      }
+
+      if (invited.user_id) {
+        throw new Error('Profile already claimed');
+      }
+
+      const { error: updateError } = await supabase
+        .from('employee_info')
+        .update({
+          user_id: userId,
+          status: 'active',
+          invitation_token: null
+        })
+        .eq('id', invited.id);
+
+      if (updateError) {
+        throw new Error('Failed to link profile to user');
+      }
+
+      return { success: true };
     } catch (error) {
       console.error('Failed to claim profile:', error);
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error occurred' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error occurred'
       };
     }
   };


### PR DESCRIPTION
## Summary
- implement employee invite flow with token generation and welcome email
- add profile claim handling with token validation
- test invitation success and claim error cases

## Testing
- `npm test` *(fails: useSignatureCanvas, AppraisalSigningModal, UploadSection snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_6892b8ee0b78832cad6a81c10f2580ce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented employee invitation functionality, allowing organizations to invite employees and send welcome emails.
  * Added the ability for invited employees to claim their profiles using invitation tokens.

* **Bug Fixes**
  * Improved profile claiming logic to ensure proper validation and error handling during the claim process.

* **Tests**
  * Introduced comprehensive tests for the employee invitation and profile claiming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->