### PR TITLE
feat(ui): provide table density via context

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,4 +1,3 @@
-
 import * as React from "react";
 import {
   ColumnDef,
@@ -101,16 +100,17 @@ export function DataTable<TData, TValue>({
 
   const table = providedTable || fallbackTable;
 
-  const { containerRef, canScrollLeft, canScrollRight, scrollLeft, scrollRight, isScrollable } = useTableScroll({
-    enableKeyboardNavigation: enableHorizontalScroll,
-    scrollBehavior: "smooth",
-    useColumnWidths: enableHorizontalScroll,
-    columns: (columns || []).map((col) => ({
-      key: col.id || "",
-      width: col.size || 150,
-      resizable: true,
-    })),
-  });
+  const { containerRef, canScrollLeft, canScrollRight, scrollLeft, scrollRight, isScrollable } =
+    useTableScroll({
+      enableKeyboardNavigation: enableHorizontalScroll,
+      scrollBehavior: "smooth",
+      useColumnWidths: enableHorizontalScroll,
+      columns: (columns || []).map((col) => ({
+        key: col.id || "",
+        width: col.size || 150,
+        resizable: true,
+      })),
+    });
 
   const stickyColumnsHook = useStickyColumns({
     columnVisibility,
@@ -138,9 +138,7 @@ export function DataTable<TData, TValue>({
               <Input
                 placeholder={searchPlaceholder}
                 value={(table.getColumn(searchKey)?.getFilterValue() as string) ?? ""}
-                onChange={(event) =>
-                  table.getColumn(searchKey)?.setFilterValue(event.target.value)
-                }
+                onChange={(event) => table.getColumn(searchKey)?.setFilterValue(event.target.value)}
                 className="h-8 w-[150px] lg:w-[250px]"
               />
             )}
@@ -173,31 +171,34 @@ export function DataTable<TData, TValue>({
             )}
           </>
         )}
-        
+
         <div
           ref={setScrollContainerRef}
           className={cn(
             "rounded-md border w-full max-w-full table-scroll-container border-l-0 border-r-0",
-            enableHorizontalScroll && "overflow-x-auto overscroll-x-none scrollbar-hide mobile-scroll md:border-l md:border-r border-border"
+            enableHorizontalScroll &&
+              "overflow-x-auto overscroll-x-none scrollbar-hide mobile-scroll md:border-l md:border-r border-border"
           )}
           data-scroll-left={canScrollLeft}
           data-scroll-right={canScrollRight}
         >
-          <Table className={cn("w-full", !enableHorizontalScroll && "table-fixed")} density={density}>
+          <Table
+            className={cn("w-full", !enableHorizontalScroll && "table-fixed")}
+            density={density}
+          >
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id} className="border-b" density={density}>
+                <TableRow key={headerGroup.id} className="border-b">
                   {headerGroup.headers.map((header) => {
                     const columnDef = header.column.columnDef;
                     const metaClassName = columnDef.meta?.className || "";
                     const width = columnDef.size ? `${columnDef.size}px` : undefined;
                     const minWidth = columnDef.minSize ? `${columnDef.minSize}px` : undefined;
                     const maxWidth = columnDef.maxSize ? `${columnDef.maxSize}px` : undefined;
-                    
+
                     return (
-                      <TableHead 
-                        key={header.id} 
-                        density={density}
+                      <TableHead
+                        key={header.id}
                         className={cn(
                           enableHorizontalScroll ? "whitespace-nowrap" : "break-words",
                           metaClassName,
@@ -212,10 +213,7 @@ export function DataTable<TData, TValue>({
                       >
                         {header.isPlaceholder
                           ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext()
-                            )}
+                          : flexRender(header.column.columnDef.header, header.getContext())}
                       </TableHead>
                     );
                   })}
@@ -227,10 +225,7 @@ export function DataTable<TData, TValue>({
                 Array.from({ length: 5 }).map((_, i) => (
                   <TableRow key={i} className="border-b">
                     {(columns || table.getAllColumns()).map((_, colIndex) => (
-                      <TableCell 
-                        key={colIndex} 
-                        className="px-4 py-3"
-                      >
+                      <TableCell key={colIndex} className="px-4 py-3">
                         <Skeleton className="h-4 w-full" />
                       </TableCell>
                     ))}
@@ -241,11 +236,7 @@ export function DataTable<TData, TValue>({
                   <TableRow
                     key={row.id}
                     data-state={row.getIsSelected() && "selected"}
-                    density={density}
-                    className={cn(
-                      "border-b hover:bg-muted/30",
-                      onRowClick && "cursor-pointer"
-                    )}
+                    className={cn("border-b hover:bg-muted/30", onRowClick && "cursor-pointer")}
                     onClick={() => onRowClick?.(row.original)}
                   >
                     {row.getVisibleCells().map((cell) => {
@@ -254,11 +245,10 @@ export function DataTable<TData, TValue>({
                       const width = columnDef.size ? `${columnDef.size}px` : undefined;
                       const minWidth = columnDef.minSize ? `${columnDef.minSize}px` : undefined;
                       const maxWidth = columnDef.maxSize ? `${columnDef.maxSize}px` : undefined;
-                      
+
                       return (
                         <TableCell
                           key={cell.id}
-                          density={density}
                           className={cn(
                             enableHorizontalScroll ? "whitespace-nowrap" : "break-words",
                             metaClassName,
@@ -271,10 +261,7 @@ export function DataTable<TData, TValue>({
                             ...stickyColumnsHook.getStickyStyle(cell.column.id),
                           }}
                         >
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </TableCell>
                       );
                     })}
@@ -290,17 +277,18 @@ export function DataTable<TData, TValue>({
                   </TableCell>
                 </TableRow>
               )}
-              {table.getRowModel().rows?.length > 0 && renderSubComponent && 
-                table.getRowModel().rows.map((row) => 
-                  row.getIsExpanded() && (
-                    <TableRow key={`${row.id}-expanded`}>
-                      <TableCell colSpan={row.getVisibleCells().length} className="px-4 py-3">
-                        {renderSubComponent({ row })}
-                      </TableCell>
-                    </TableRow>
-                  )
-                )
-              }
+              {table.getRowModel().rows?.length > 0 &&
+                renderSubComponent &&
+                table.getRowModel().rows.map(
+                  (row) =>
+                    row.getIsExpanded() && (
+                      <TableRow key={`${row.id}-expanded`}>
+                        <TableCell colSpan={row.getVisibleCells().length} className="px-4 py-3">
+                          {renderSubComponent({ row })}
+                        </TableCell>
+                      </TableRow>
+                    )
+                )}
             </TableBody>
           </Table>
         </div>
@@ -337,8 +325,7 @@ export function DataTable<TData, TValue>({
               </select>
             </div>
             <div className="flex w-[100px] items-center justify-center text-sm font-medium">
-              Page {table.getState().pagination.pageIndex + 1} of{" "}
-              {table.getPageCount()}
+              Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
             </div>
             <div className="flex items-center space-x-2">
               <Button

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "@/lib/utils"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const tableVariants = cva("w-full caption-bottom", {
   variants: {
@@ -13,7 +13,11 @@ const tableVariants = cva("w-full caption-bottom", {
   defaultVariants: {
     density: "comfortable",
   },
-})
+});
+
+type TableDensity = NonNullable<VariantProps<typeof tableVariants>["density"]>;
+
+const TableContext = React.createContext<{ density: TableDensity } | undefined>(undefined);
 
 const tableRowVariants = cva(
   "group border-b transition-colors cursor-pointer select-text hover:bg-muted/30 data-[state=selected]:bg-muted/60",
@@ -29,7 +33,7 @@ const tableRowVariants = cva(
       density: "comfortable",
     },
   }
-)
+);
 
 const tableHeadVariants = cva(
   "text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 bg-muted/10",
@@ -45,58 +49,53 @@ const tableHeadVariants = cva(
       density: "comfortable",
     },
   }
-)
+);
 
-const tableCellVariants = cva(
-  "align-middle [&:has([role=checkbox])]:pr-0",
-  {
-    variants: {
-      density: {
-        compact: "px-3 py-2 text-xs",
-        comfortable: "px-4 py-3 text-sm",
-        spacious: "px-6 py-4 text-base",
-      },
+const tableCellVariants = cva("align-middle [&:has([role=checkbox])]:pr-0", {
+  variants: {
+    density: {
+      compact: "px-3 py-2 text-xs",
+      comfortable: "px-4 py-3 text-sm",
+      spacious: "px-6 py-4 text-base",
     },
-    defaultVariants: {
-      density: "comfortable",
-    },
-  }
-)
+  },
+  defaultVariants: {
+    density: "comfortable",
+  },
+});
 
 export interface TableProps
   extends React.HTMLAttributes<HTMLTableElement>,
     VariantProps<typeof tableVariants> {}
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>(
-  ({ className, density, ...props }, ref) => (
-    <table
-      ref={ref}
-      className={cn(tableVariants({ density, className }))}
-      {...props}
-    />
-  )
-)
-Table.displayName = "Table"
+  ({ className, density, ...props }, ref) => {
+    const contextValue = React.useMemo(() => ({ density: density ?? "comfortable" }), [density]);
+
+    return (
+      <TableContext.Provider value={contextValue}>
+        <table ref={ref} className={cn(tableVariants({ density, className }))} {...props} />
+      </TableContext.Provider>
+    );
+  }
+);
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
   <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+));
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -104,73 +103,79 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = "TableFooter";
 
 export interface TableRowProps
   extends React.HTMLAttributes<HTMLTableRowElement>,
     VariantProps<typeof tableRowVariants> {}
 
 const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
-  ({ className, density, ...props }, ref) => (
-    <tr
-      ref={ref}
-      className={cn(tableRowVariants({ density, className }))}
-      {...props}
-    />
-  )
-)
-TableRow.displayName = "TableRow"
+  ({ className, density, ...props }, ref) => {
+    const context = React.useContext(TableContext);
+    const tableDensity = density ?? context?.density ?? "comfortable";
+    return (
+      <tr
+        ref={ref}
+        className={cn(tableRowVariants({ density: tableDensity, className }))}
+        {...props}
+      />
+    );
+  }
+);
+TableRow.displayName = "TableRow";
 
 export interface TableHeadProps
   extends React.ThHTMLAttributes<HTMLTableCellElement>,
     VariantProps<typeof tableHeadVariants> {}
 
 const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
-  ({ className, density, ...props }, ref) => (
-    <th
-      ref={ref}
-      className={cn(tableHeadVariants({ density, className }))}
-      {...props}
-    />
-  )
-)
-TableHead.displayName = "TableHead"
+  ({ className, density, ...props }, ref) => {
+    const context = React.useContext(TableContext);
+    const tableDensity = density ?? context?.density ?? "comfortable";
+    return (
+      <th
+        ref={ref}
+        className={cn(tableHeadVariants({ density: tableDensity, className }))}
+        {...props}
+      />
+    );
+  }
+);
+TableHead.displayName = "TableHead";
 
 export interface TableCellProps
   extends React.TdHTMLAttributes<HTMLTableCellElement>,
     VariantProps<typeof tableCellVariants> {}
 
 const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
-  ({ className, density, ...props }, ref) => (
-    <td
-      ref={ref}
-      className={cn(tableCellVariants({ density, className }))}
-      {...props}
-    />
-  )
-)
-TableCell.displayName = "TableCell"
+  ({ className, density, ...props }, ref) => {
+    const context = React.useContext(TableContext);
+    const tableDensity = density ?? context?.density ?? "comfortable";
+    return (
+      <td
+        ref={ref}
+        className={cn(tableCellVariants({ density: tableDensity, className }))}
+        {...props}
+      />
+    );
+  }
+);
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
+  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+));
+TableCaption.displayName = "TableCaption";
 
 export {
+  TableContext,
   Table,
   TableHeader,
   TableBody,
@@ -179,4 +184,4 @@ export {
   TableRow,
   TableCell,
   TableCaption,
-}
+};


### PR DESCRIPTION
## Summary
- add `TableContext` to provide table density
- default `TableRow`, `TableHead`, and `TableCell` to density from context
- remove redundant density props in `DataTable`

## Testing
- `npm test` *(fails: useDemoMode must be used within a DemoModeProvider)*
- `npm run lint` *(fails: resolve error: typescript with invalid interface loaded as resolver)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ba1be08832c950d2d869013cc9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Table density now cascades from the parent Table to all parts (headers, rows, cells, etc.) for consistent spacing and appearance.

- Refactor
  - Simplified internal rendering logic for rows (including expanded rows) and handlers without changing behavior.
  - Streamlined DataTable internals while keeping its public behavior unchanged.

- Style
  - Minor visual tweaks to pagination text formatting (e.g., condensed “Page X of Y”).
  - Small spacing/formatting adjustments for a more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->